### PR TITLE
core: clean up methods on the IR

### DIFF
--- a/optd/core/src/ir/convert.rs
+++ b/optd/core/src/ir/convert.rs
@@ -26,11 +26,7 @@ impl Operator {
         T::try_from_operator(self)
     }
 
-    pub fn try_bind_ref<T: TryFromOperator>(&self) -> Result<T, OperatorKind> {
-        T::try_from_operator(self.clone())
-    }
-
-    pub fn try_bind_ref_experimental<O>(
+    pub fn try_borrow<O>(
         &self,
     ) -> Result<<O as TryBorrowOperatorMarker<'_>>::BorrowedType, &OperatorKind>
     where
@@ -64,11 +60,7 @@ impl Scalar {
         T::try_from_scalar(self)
     }
 
-    pub fn try_bind_ref<T: TryFromScalar>(&self) -> Result<T, ScalarKind> {
-        T::try_from_scalar(self.clone())
-    }
-
-    pub fn try_bind_ref_experimental<S>(
+    pub fn try_borrow<S>(
         &self,
     ) -> Result<<S as TryBorrowScalarMarker<'_>>::BorrowedType, &ScalarKind>
     where

--- a/optd/core/src/ir/macros.rs
+++ b/optd/core/src/ir/macros.rs
@@ -133,6 +133,14 @@ macro_rules! generate_common_node {
                 }
             }
 
+            /// Constructs the operator from raw metadata and IR inputs.
+            pub fn borrow_raw_parts<'ir>(meta: &'ir $metadata_type, common: &'ir crate::ir::IRCommon<$props_type>) -> $ref_name<'ir> {
+                $ref_name {
+                    meta,
+                    common,
+                }
+            }
+
             /// Gets a slice to the input operators.
             pub fn input_operators(&self) -> &[std::sync::Arc<crate::ir::Operator>] {
                 &self.common.input_operators
@@ -144,15 +152,7 @@ macro_rules! generate_common_node {
             }
         }
 
-        impl<'ir> $ref_name<'ir> {
-            /// Constructs the operator from raw metadata and IR inputs.
-            pub fn from_raw_parts(meta: &'ir $metadata_type, common: &'ir crate::ir::IRCommon<$props_type>) -> Self {
-                Self {
-                    meta,
-                    common,
-                }
-            }
-        }
+
     };
 }
 
@@ -264,7 +264,7 @@ macro_rules! impl_scalar_conversion {
             ) -> Result<Self, &'a crate::ir::ScalarKind> {
                 match &scalar.kind {
                     crate::ir::ScalarKind::$node_name(meta) => {
-                        Ok($ref_name::from_raw_parts(meta, &scalar.common))
+                        Ok($node_name::borrow_raw_parts(meta, &scalar.common))
                     }
                     other_kind => Err(other_kind),
                 }
@@ -308,7 +308,7 @@ macro_rules! impl_operator_conversion {
             ) -> Result<Self, &'a crate::ir::OperatorKind> {
                 match &operator.kind {
                     crate::ir::OperatorKind::$node_name(meta) => {
-                        Ok($ref_name::from_raw_parts(meta, &operator.common))
+                        Ok($node_name::borrow_raw_parts(meta, &operator.common))
                     }
                     other_kind => Err(other_kind),
                 }

--- a/optd/core/src/ir/operator/logical/get.rs
+++ b/optd/core/src/ir/operator/logical/get.rs
@@ -31,21 +31,13 @@ impl LogicalGet {
     }
 }
 
-impl Derive<OutputColumns> for LogicalGet {
+impl Derive<OutputColumns> for LogicalGetBorrowed<'_> {
     fn derive_by_compute(&self, _ctx: &crate::ir::context::IRContext) -> OutputColumns {
         let projections = self
             .projection_list()
             .try_borrow::<ProjectionList>()
             .expect("projection_list should typecheck");
         OutputColumns::from_column_set(projections.get_all_assignees().collect())
-    }
-
-    fn derive(&self, ctx: &crate::ir::context::IRContext) -> OutputColumns {
-        self.common
-            .properties
-            .output_columns
-            .get_or_init(|| self.derive_by_compute(ctx))
-            .clone()
     }
 }
 
@@ -68,7 +60,7 @@ impl LogicalGet {
 
 #[cfg(test)]
 mod tests {
-    use crate::ir::{Column, context::IRContext, convert::IntoOperator, properties::GetProperty};
+    use crate::ir::{Column, context::IRContext, convert::IntoOperator};
 
     use super::*;
 
@@ -76,8 +68,8 @@ mod tests {
     fn logical_get_construct_and_access() {
         let ctx = IRContext::with_course_tables();
         let op = LogicalGet::mock(vec![0, 1]).into_operator();
-        let output_columns = op.get_property::<OutputColumns>(&ctx);
-        let set = output_columns.set();
+        let output_columns = op.output_columns(&ctx);
+        let set = &*output_columns;
         assert_eq!(set.len(), 2);
         assert!(set.contains(&Column(0)));
         assert!(set.contains(&Column(1)));

--- a/optd/core/src/ir/operator/logical/get.rs
+++ b/optd/core/src/ir/operator/logical/get.rs
@@ -35,7 +35,7 @@ impl Derive<OutputColumns> for LogicalGet {
     fn derive_by_compute(&self, _ctx: &crate::ir::context::IRContext) -> OutputColumns {
         let projections = self
             .projection_list()
-            .try_bind_ref::<ProjectionList>()
+            .try_borrow::<ProjectionList>()
             .expect("projection_list should typecheck");
         OutputColumns::from_column_set(projections.get_all_assignees().collect())
     }
@@ -81,6 +81,6 @@ mod tests {
         assert_eq!(set.len(), 2);
         assert!(set.contains(&Column(0)));
         assert!(set.contains(&Column(1)));
-        assert!(op.try_bind_ref::<LogicalGet>().is_ok());
+        assert!(op.try_borrow::<LogicalGet>().is_ok());
     }
 }

--- a/optd/core/src/ir/operator/logical/order_by.rs
+++ b/optd/core/src/ir/operator/logical/order_by.rs
@@ -47,7 +47,7 @@ impl LogicalOrderBy {
             .exprs()
             .iter()
             .map(|expr| {
-                expr.try_bind_ref::<ColumnRef>()
+                expr.try_borrow::<ColumnRef>()
                     .map(|column_ref| *column_ref.column())
                     .map_err(|_| expr.clone())
             })
@@ -131,6 +131,6 @@ mod tests {
         let res = order_by.try_extract_tuple_ordering().unwrap_err();
 
         assert_eq!(res.len(), 1);
-        res[0].try_bind_ref::<BinaryOp>().unwrap();
+        assert!(res[0].try_borrow::<BinaryOp>().is_ok())
     }
 }

--- a/optd/core/src/ir/operator/mod.rs
+++ b/optd/core/src/ir/operator/mod.rs
@@ -21,7 +21,7 @@ pub use physical::mock_scan::*;
 
 use crate::ir::explain::Explain;
 use crate::ir::properties::OperatorProperties;
-use crate::ir::{GroupBorrowed, GroupId, GroupMetadata, IRCommon, Scalar};
+use crate::ir::{Group, GroupId, GroupMetadata, IRCommon, Scalar};
 
 /// The operator type and its associated metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -124,27 +124,27 @@ impl Explain for Operator {
     ) -> pretty_xmlish::Pretty<'a> {
         match &self.kind {
             OperatorKind::Group(meta) => {
-                GroupBorrowed::from_raw_parts(meta, &self.common).explain(ctx, option)
+                Group::borrow_raw_parts(meta, &self.common).explain(ctx, option)
             }
             OperatorKind::MockScan(meta) => {
-                MockScanBorrowed::from_raw_parts(meta, &self.common).explain(ctx, option)
+                MockScan::borrow_raw_parts(meta, &self.common).explain(ctx, option)
             }
             OperatorKind::LogicalGet(_) => todo!(),
             OperatorKind::LogicalJoin(meta) => {
-                LogicalJoinBorrowed::from_raw_parts(meta, &self.common).explain(ctx, option)
+                LogicalJoin::borrow_raw_parts(meta, &self.common).explain(ctx, option)
             }
             OperatorKind::LogicalSelect(meta) => {
-                LogicalSelectBorrowed::from_raw_parts(meta, &self.common).explain(ctx, option)
+                LogicalSelect::borrow_raw_parts(meta, &self.common).explain(ctx, option)
             }
             OperatorKind::EnforcerSort(meta) => {
-                EnforcerSortBorrowed::from_raw_parts(meta, &self.common).explain(ctx, option)
+                EnforcerSort::borrow_raw_parts(meta, &self.common).explain(ctx, option)
             }
             OperatorKind::PhysicalTableScan(_) => todo!(),
             OperatorKind::PhysicalNLJoin(meta) => {
-                PhysicalNLJoinBorrowed::from_raw_parts(meta, &self.common).explain(ctx, option)
+                PhysicalNLJoin::borrow_raw_parts(meta, &self.common).explain(ctx, option)
             }
             OperatorKind::PhysicalFilter(meta) => {
-                PhysicalFilterBorrowed::from_raw_parts(meta, &self.common).explain(ctx, option)
+                PhysicalFilter::borrow_raw_parts(meta, &self.common).explain(ctx, option)
             }
         }
     }

--- a/optd/core/src/ir/operator/physical/table_scan.rs
+++ b/optd/core/src/ir/operator/physical/table_scan.rs
@@ -35,7 +35,7 @@ impl Derive<OutputColumns> for PhysicalTableScan {
     fn derive_by_compute(&self, _ctx: &crate::ir::context::IRContext) -> OutputColumns {
         let projections = self
             .projection_list()
-            .try_bind_ref::<ProjectionList>()
+            .try_borrow::<ProjectionList>()
             .unwrap();
         OutputColumns::from_column_set(projections.get_all_assignees().collect())
     }

--- a/optd/core/src/ir/operator/physical/table_scan.rs
+++ b/optd/core/src/ir/operator/physical/table_scan.rs
@@ -31,21 +31,13 @@ impl PhysicalTableScan {
     }
 }
 
-impl Derive<OutputColumns> for PhysicalTableScan {
+impl Derive<OutputColumns> for PhysicalTableScanBorrowed<'_> {
     fn derive_by_compute(&self, _ctx: &crate::ir::context::IRContext) -> OutputColumns {
         let projections = self
             .projection_list()
             .try_borrow::<ProjectionList>()
             .unwrap();
         OutputColumns::from_column_set(projections.get_all_assignees().collect())
-    }
-
-    fn derive(&self, ctx: &crate::ir::context::IRContext) -> OutputColumns {
-        self.common
-            .properties
-            .output_columns
-            .get_or_init(|| self.derive_by_compute(ctx))
-            .clone()
     }
 }
 

--- a/optd/core/src/ir/properties/mod.rs
+++ b/optd/core/src/ir/properties/mod.rs
@@ -21,18 +21,20 @@ pub struct OperatorProperties {
 #[derive(Debug, Default)]
 pub struct ScalarProperties;
 
-pub trait PropertyMarker {}
+pub trait PropertyMarker {
+    type Output;
+}
 
 pub trait Derive<P: PropertyMarker> {
-    fn derive_by_compute(&self, ctx: &IRContext) -> P;
+    fn derive_by_compute(&self, ctx: &IRContext) -> P::Output;
 
-    fn derive(&self, ctx: &IRContext) -> P {
+    fn derive(&self, ctx: &IRContext) -> P::Output {
         self.derive_by_compute(ctx)
     }
 }
 
 pub trait GetProperty {
-    fn get_property<P>(&self, ctx: &IRContext) -> P
+    fn get_property<P>(&self, ctx: &IRContext) -> P::Output
     where
         Self: Derive<P>,
         P: PropertyMarker,
@@ -41,6 +43,8 @@ pub trait GetProperty {
     }
 }
 
-pub trait TrySatisfy<P: PropertyMarker> {
+impl GetProperty for crate::ir::Operator {}
+
+pub trait TrySatisfy<P> {
     fn try_satisfy(&self, property: &P, ctx: &IRContext) -> Option<Arc<[P]>>;
 }

--- a/optd/core/src/ir/properties/required.rs
+++ b/optd/core/src/ir/properties/required.rs
@@ -19,7 +19,9 @@ impl std::fmt::Display for Required {
     }
 }
 
-impl PropertyMarker for Arc<Required> {}
+impl PropertyMarker for Arc<Required> {
+    type Output = Self;
+}
 
 impl crate::ir::properties::TrySatisfy<Arc<Required>> for Operator {
     fn try_satisfy(

--- a/optd/core/src/ir/scalar/assign.rs
+++ b/optd/core/src/ir/scalar/assign.rs
@@ -31,7 +31,7 @@ impl Assign {
 
     pub fn is_passthrough(&self) -> bool {
         self.expr()
-            .try_bind_ref::<ColumnRef>()
+            .try_borrow::<ColumnRef>()
             .is_ok_and(|column_ref| column_ref.column() == self.assignee())
     }
 }

--- a/optd/core/src/ir/scalar/mod.rs
+++ b/optd/core/src/ir/scalar/mod.rs
@@ -78,15 +78,15 @@ impl Explain for Scalar {
     ) -> pretty_xmlish::Pretty<'a> {
         match &self.kind {
             ScalarKind::Literal(meta) => {
-                LiteralBorrowed::from_raw_parts(meta, &self.common).explain(ctx, option)
+                Literal::borrow_raw_parts(meta, &self.common).explain(ctx, option)
             }
             ScalarKind::ColumnRef(meta) => {
-                ColumnRefBorrowed::from_raw_parts(meta, &self.common).explain(ctx, option)
+                ColumnRef::borrow_raw_parts(meta, &self.common).explain(ctx, option)
             }
             ScalarKind::Assign(_) => todo!(),
             ScalarKind::ProjectionList(_) => todo!(),
             ScalarKind::BinaryOp(meta) => {
-                BinaryOpBorrowed::from_raw_parts(meta, &self.common).explain(ctx, option)
+                BinaryOp::borrow_raw_parts(meta, &self.common).explain(ctx, option)
             }
         }
     }

--- a/optd/core/src/ir/scalar/projection_list.rs
+++ b/optd/core/src/ir/scalar/projection_list.rs
@@ -26,10 +26,12 @@ impl ProjectionList {
             common: IRCommon::with_input_scalars_only(members),
         }
     }
+}
 
+impl ProjectionListBorrowed<'_> {
     pub fn get_all_assignees(&self) -> impl Iterator<Item = Column> {
         self.members().iter().map(|member| {
-            let assign = member.try_bind_ref::<Assign>().unwrap();
+            let assign = member.try_borrow::<Assign>().unwrap();
             *assign.assignee()
         })
     }

--- a/optd/core/src/magic/card.rs
+++ b/optd/core/src/magic/card.rs
@@ -34,7 +34,7 @@ impl CardinalityEstimator for MagicCardinalityEstimator {
             }
             OperatorKind::LogicalJoin(meta) => {
                 let join = LogicalJoinBorrowed::from_raw_parts(meta, &op.common);
-                let selectivity = if let Ok(literal) = join.join_cond().try_bind_ref::<Literal>() {
+                let selectivity = if let Ok(literal) = join.join_cond().try_borrow::<Literal>() {
                     match literal.value() {
                         crate::ir::ScalarValue::Boolean(Some(true)) => 1.,
                         crate::ir::ScalarValue::Boolean(_) => 0.,
@@ -49,7 +49,7 @@ impl CardinalityEstimator for MagicCardinalityEstimator {
             }
             OperatorKind::PhysicalNLJoin(meta) => {
                 let join = PhysicalNLJoinBorrowed::from_raw_parts(meta, &op.common);
-                let selectivity = if let Ok(literal) = join.join_cond().try_bind_ref::<Literal>() {
+                let selectivity = if let Ok(literal) = join.join_cond().try_borrow::<Literal>() {
                     match literal.value() {
                         crate::ir::ScalarValue::Boolean(Some(true)) => 1.,
                         crate::ir::ScalarValue::Boolean(_) => 0.,
@@ -64,8 +64,7 @@ impl CardinalityEstimator for MagicCardinalityEstimator {
             }
             OperatorKind::LogicalSelect(meta) => {
                 let filter = LogicalSelectBorrowed::from_raw_parts(meta, &op.common);
-                let selectivity = if let Ok(literal) = filter.predicate().try_bind_ref::<Literal>()
-                {
+                let selectivity = if let Ok(literal) = filter.predicate().try_borrow::<Literal>() {
                     match literal.value() {
                         crate::ir::ScalarValue::Boolean(Some(true)) => 1.,
                         crate::ir::ScalarValue::Boolean(_) => 0.,
@@ -79,8 +78,7 @@ impl CardinalityEstimator for MagicCardinalityEstimator {
             }
             OperatorKind::PhysicalFilter(meta) => {
                 let filter = PhysicalFilterBorrowed::from_raw_parts(meta, &op.common);
-                let selectivity = if let Ok(literal) = filter.predicate().try_bind_ref::<Literal>()
-                {
+                let selectivity = if let Ok(literal) = filter.predicate().try_borrow::<Literal>() {
                     match literal.value() {
                         crate::ir::ScalarValue::Boolean(Some(true)) => 1.,
                         crate::ir::ScalarValue::Boolean(_) => 0.,

--- a/optd/core/src/magic/card.rs
+++ b/optd/core/src/magic/card.rs
@@ -1,6 +1,6 @@
 use crate::ir::{
     operator::*,
-    properties::{Cardinality, CardinalityEstimator, GetProperty},
+    properties::{Cardinality, CardinalityEstimator},
     scalar::*,
 };
 
@@ -33,7 +33,7 @@ impl CardinalityEstimator for MagicCardinalityEstimator {
                 Cardinality::with_count_lossy(exact_row_count)
             }
             OperatorKind::LogicalJoin(meta) => {
-                let join = LogicalJoinBorrowed::from_raw_parts(meta, &op.common);
+                let join = LogicalJoin::borrow_raw_parts(meta, &op.common);
                 let selectivity = if let Ok(literal) = join.join_cond().try_borrow::<Literal>() {
                     match literal.value() {
                         crate::ir::ScalarValue::Boolean(Some(true)) => 1.,
@@ -43,12 +43,12 @@ impl CardinalityEstimator for MagicCardinalityEstimator {
                 } else {
                     MagicCardinalityEstimator::MAGIC_JOIN_COND_SELECTIVITY
                 };
-                let left_card = join.outer().get_property::<Cardinality>(ctx);
-                let right_card = join.inner().get_property::<Cardinality>(ctx);
+                let left_card = join.outer().cardinality(ctx);
+                let right_card = join.inner().cardinality(ctx);
                 selectivity * left_card * right_card
             }
             OperatorKind::PhysicalNLJoin(meta) => {
-                let join = PhysicalNLJoinBorrowed::from_raw_parts(meta, &op.common);
+                let join = PhysicalNLJoin::borrow_raw_parts(meta, &op.common);
                 let selectivity = if let Ok(literal) = join.join_cond().try_borrow::<Literal>() {
                     match literal.value() {
                         crate::ir::ScalarValue::Boolean(Some(true)) => 1.,
@@ -58,12 +58,12 @@ impl CardinalityEstimator for MagicCardinalityEstimator {
                 } else {
                     MagicCardinalityEstimator::MAGIC_JOIN_COND_SELECTIVITY
                 };
-                let left_card = join.outer().get_property::<Cardinality>(ctx);
-                let right_card = join.inner().get_property::<Cardinality>(ctx);
+                let left_card = join.outer().cardinality(ctx);
+                let right_card = join.inner().cardinality(ctx);
                 selectivity * left_card * right_card
             }
             OperatorKind::LogicalSelect(meta) => {
-                let filter = LogicalSelectBorrowed::from_raw_parts(meta, &op.common);
+                let filter = LogicalSelect::borrow_raw_parts(meta, &op.common);
                 let selectivity = if let Ok(literal) = filter.predicate().try_borrow::<Literal>() {
                     match literal.value() {
                         crate::ir::ScalarValue::Boolean(Some(true)) => 1.,
@@ -74,10 +74,10 @@ impl CardinalityEstimator for MagicCardinalityEstimator {
                     Self::MAGIC_PREDICATE_SELECTIVITY
                 };
 
-                selectivity * op.input_operators()[0].get_property::<Cardinality>(ctx)
+                selectivity * filter.input().cardinality(ctx)
             }
             OperatorKind::PhysicalFilter(meta) => {
-                let filter = PhysicalFilterBorrowed::from_raw_parts(meta, &op.common);
+                let filter = PhysicalFilter::borrow_raw_parts(meta, &op.common);
                 let selectivity = if let Ok(literal) = filter.predicate().try_borrow::<Literal>() {
                     match literal.value() {
                         crate::ir::ScalarValue::Boolean(Some(true)) => 1.,
@@ -88,11 +88,11 @@ impl CardinalityEstimator for MagicCardinalityEstimator {
                     Self::MAGIC_PREDICATE_SELECTIVITY
                 };
 
-                selectivity * op.input_operators()[0].get_property::<Cardinality>(ctx)
+                selectivity * filter.input().cardinality(ctx)
             }
-            OperatorKind::EnforcerSort(_) => {
-                op.input_operators()[0].get_property::<Cardinality>(ctx)
-            }
+            OperatorKind::EnforcerSort(meta) => EnforcerSort::borrow_raw_parts(meta, &op.common)
+                .input()
+                .cardinality(ctx),
             OperatorKind::MockScan(meta) => meta.spec.mocked_card,
         }
     }

--- a/optd/core/src/rules/implementations/table_scan.rs
+++ b/optd/core/src/rules/implementations/table_scan.rs
@@ -37,7 +37,7 @@ impl Rule for LogicalGetAsPhysicalTableScanRule {
         operator: &crate::ir::Operator,
         _ctx: &crate::ir::IRContext,
     ) -> Result<Vec<std::sync::Arc<crate::ir::Operator>>, ()> {
-        let get = operator.try_bind_ref::<LogicalGet>().unwrap();
+        let get = operator.try_borrow::<LogicalGet>().unwrap();
         let table_scan = PhysicalTableScan::new(*get.table_id(), get.projection_list().clone());
         Ok(vec![table_scan.into_operator()])
     }

--- a/optd/core/src/rules/logical_join_inner_assoc.rs
+++ b/optd/core/src/rules/logical_join_inner_assoc.rs
@@ -71,7 +71,7 @@ impl Rule for LogicalJoinInnerAssocRule {
 mod tests {
     use crate::ir::{
         ScalarValue,
-        convert::IntoScalar,
+        convert::{IntoOperator, IntoScalar},
         operator::{MockScan, MockSpec},
         scalar::Literal,
     };

--- a/optd/core/tests/it_works.rs
+++ b/optd/core/tests/it_works.rs
@@ -38,7 +38,7 @@ async fn optimize_plan(
     println!("\nMEMO AFTER OPT");
     opt.memo.read().await.dump();
 
-    println!("\nEXPLAIN (root_requirement: {}):", required);
+    println!("\nEXPLAIN (root_requirement: {required}):");
     std::iter::once(format!("{:<initial_len$}", "initial plan:").as_str())
         .chain(initial_explained)
         .zip_longest(std::iter::once("final plan:").chain(optimized_explained))


### PR DESCRIPTION
## Problem


Some methods are added to the IR as experimental features. We also got feedback from the dev meeting that the rule seems hard to read (or long). We would like to clean up these rough edges.


## Summary of changes

- eliminate`try_bind_ref_xxx` and use `try_borrow`
- add `borrow_raw_parts` so we always refer to `$node_name` instead of `$ref_name`.
- Plumb through property methods to use shorthand.

**_TODO:_** Pattern builder can also be generated by macros.
