### PR TITLE
fix(ci): disable catalog tests on windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,8 @@
 [workspace]
 resolver = "2"
 members = ["cli", "connectors/datafusion", "optd/core", "optd/catalog"]
+default-members = ["optd/core", "optd/catalog", "connectors/datafusion"]
+
 
 [workspace.dependencies]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,15 +19,15 @@ tokio = { workspace = true, features = [
 ] }
 dirs = "6.0.0"
 regex = "1.8"
-object_store = "0.12.3"
+object_store = "0.12.4"
 url = "2.5.4"
-tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 tracing = { workspace = true }
 
 futures = "0.3.31"
 optd-catalog = { path = "../optd/catalog", version = "0.1" }
-parquet = "57.1.0"
-serde_json = "1.0"
+parquet = "57.2"
+serde_json = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/cli/tests/catalog_service_integration.rs
+++ b/cli/tests/catalog_service_integration.rs
@@ -1,4 +1,5 @@
-// Integration tests for optd catalog service handle functions
+#![cfg(not(target_os = "windows"))]
+//! Integration tests for optd catalog service handle functions
 
 use datafusion::{
     arrow::array::{Int32Array, RecordBatch},

--- a/connectors/datafusion/tests/integration_test.rs
+++ b/connectors/datafusion/tests/integration_test.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_os = "windows"))]
+
 use datafusion::{
     arrow::{
         array::{Float64Array, Int32Array, Int64Array, RecordBatch, StringArray},

--- a/connectors/datafusion/tests/table_loading_test.rs
+++ b/connectors/datafusion/tests/table_loading_test.rs
@@ -1,3 +1,4 @@
+#![cfg(not(target_os = "windows"))]
 //! Integration tests for lazy loading tables from catalog
 
 use datafusion::{

--- a/optd/catalog/tests/catalog_error_tests.rs
+++ b/optd/catalog/tests/catalog_error_tests.rs
@@ -1,4 +1,5 @@
-// Catalog error handling tests
+//! Catalog error handling tests
+#![cfg(not(target_os = "windows"))]
 
 use optd_catalog::{CatalogService, CatalogServiceHandle, DuckLakeCatalog};
 use tempfile::TempDir;
@@ -51,7 +52,6 @@ async fn test_error_get_nonexistent_table_metadata() {
 }
 
 #[tokio::test]
-#[ignore]
 async fn test_error_drop_nonexistent_table() {
     let (_temp_dir, service, handle) = create_test_service();
 
@@ -203,7 +203,6 @@ async fn test_current_schema_for_nonexistent_table() {
 }
 
 #[tokio::test]
-#[ignore]
 async fn test_current_schema_with_different_schemas() {
     use optd_catalog::RegisterTableRequest;
     use std::collections::HashMap;
@@ -464,7 +463,6 @@ async fn test_special_characters_in_names() {
 }
 
 #[tokio::test]
-#[ignore]
 async fn test_concurrent_catalog_modifications() {
     use optd_catalog::RegisterTableRequest;
     use std::collections::HashMap;
@@ -529,7 +527,6 @@ async fn test_concurrent_catalog_modifications() {
 }
 
 #[tokio::test]
-#[ignore]
 async fn test_concurrent_statistics_updates() {
     use optd_catalog::{RegisterTableRequest, TableStatistics};
     use std::collections::HashMap;

--- a/optd/catalog/tests/external_tables_tests.rs
+++ b/optd/catalog/tests/external_tables_tests.rs
@@ -1,5 +1,6 @@
 //! External table registration, retrieval, and management tests.
 //! Tests both direct API calls and service layer (async RPC).
+#![cfg(not(target_os = "windows"))]
 
 use optd_catalog::{Catalog, CatalogService, DuckLakeCatalog, RegisterTableRequest};
 use std::collections::HashMap;

--- a/optd/catalog/tests/schema_tests.rs
+++ b/optd/catalog/tests/schema_tests.rs
@@ -1,4 +1,5 @@
 //! Multi-schema support tests: CRUD operations, isolation, and complex queries.
+#![cfg(not(target_os = "windows"))]
 
 use optd_catalog::{Catalog, DuckLakeCatalog, RegisterTableRequest};
 use std::collections::HashMap;

--- a/optd/catalog/tests/service_tests.rs
+++ b/optd/catalog/tests/service_tests.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_os = "windows"))]
+
 use optd_catalog::{CatalogService, CatalogServiceHandle, DuckLakeCatalog};
 use std::time::Duration;
 use tempfile::TempDir;

--- a/optd/catalog/tests/statistics_tests.rs
+++ b/optd/catalog/tests/statistics_tests.rs
@@ -1,5 +1,6 @@
 //! Comprehensive statistics tests for both internal and external tables.
 //! Covers snapshot versioning, time-travel queries, and edge cases.
+#![cfg(not(target_os = "windows"))]
 
 use optd_catalog::{
     AdvanceColumnStatistics, Catalog, ColumnStatistics, DuckLakeCatalog, RegisterTableRequest,


### PR DESCRIPTION
Accessing the DuckDB extensions concurrently across multiple processes causes problems on Windows. Turning off all catalog tests on Windows for now. A more permanent fix is to use different temporary locations for installing extensions for each process.