### PR TITLE
minor fixes

### DIFF
--- a/optd/core/src/ir/properties/output_columns.rs
+++ b/optd/core/src/ir/properties/output_columns.rs
@@ -82,7 +82,7 @@ impl Derive<OutputColumns> for crate::ir::Operator {
             OperatorKind::LogicalAggregate(meta) => {
                 let agg = LogicalAggregate::borrow_raw_parts(meta, &self.common);
                 let exprs = agg.exprs().try_borrow::<List>().unwrap();
-                let keys = agg.exprs().try_borrow::<List>().unwrap();
+                let keys = agg.keys().try_borrow::<List>().unwrap();
                 let set = exprs
                     .members()
                     .iter()
@@ -97,7 +97,7 @@ impl Derive<OutputColumns> for crate::ir::Operator {
             OperatorKind::PhysicalHashAggregate(meta) => {
                 let agg = PhysicalHashAggregate::borrow_raw_parts(meta, &self.common);
                 let exprs = agg.exprs().try_borrow::<List>().unwrap();
-                let keys = agg.exprs().try_borrow::<List>().unwrap();
+                let keys = agg.keys().try_borrow::<List>().unwrap();
                 let set = exprs
                     .members()
                     .iter()

--- a/optd/core/src/rules/implementations/hash_join.rs
+++ b/optd/core/src/rules/implementations/hash_join.rs
@@ -100,6 +100,10 @@ impl Rule for LogicalJoinAsPhysicalHashJoinRule {
 
         let (equi_conds, non_equi_conds) = Self::split_equi_and_non_equi_conditions(&join, ctx)?;
 
+        if equi_conds.is_empty() {
+            return Ok(vec![]);
+        }
+
         let build_side = join.outer().clone();
         let probe_side = join.inner().clone();
 

--- a/optd/core/src/rules/logical_join_inner_assoc.rs
+++ b/optd/core/src/rules/logical_join_inner_assoc.rs
@@ -61,7 +61,7 @@ impl Rule for LogicalJoinInnerAssocRule {
         if !join_upper
             .join_cond()
             .used_columns()
-            .is_subset(&(&*b.output_columns(ctx) & &*c.output_columns(ctx)))
+            .is_subset(&(&*b.output_columns(ctx) | &*c.output_columns(ctx)))
         {
             return Ok(vec![]);
         }


### PR DESCRIPTION
Minor fixes to the core optimizer.

## Summary of changes

- aggregate output column should be exprs + keys
- hash join implementation early returns if the equi condition is empty
- join condition usage should be tested with the union of output columns from outer + inner side of join