### PR TITLE
Add nodes to allow Subqueries to be processed

### DIFF
--- a/connectors/datafusion/src/planner.rs
+++ b/connectors/datafusion/src/planner.rs
@@ -833,6 +833,18 @@ impl OptdQueryPlanner {
                 let join_type = match join.join_type() {
                     join::JoinType::Inner => logical_expr::JoinType::Inner,
                     join::JoinType::Left => logical_expr::JoinType::Left,
+                    join::JoinType::Single => {
+                        return Err(DataFusionError::NotImplemented(
+                            "single join is not supported in datafusion physical planning"
+                                .to_string(),
+                        ));
+                    }
+                    join::JoinType::Mark(_) => {
+                        return Err(DataFusionError::NotImplemented(
+                            "mark join is not supported in datafusion physical planning"
+                                .to_string(),
+                        ));
+                    }
                 };
                 let left_dfschema = from_optd_schema(&join.outer().output_schema(ctx).unwrap());
                 let right_dfschema = from_optd_schema(&join.inner().output_schema(ctx).unwrap());
@@ -930,6 +942,18 @@ impl OptdQueryPlanner {
                 let join_type = match join.join_type() {
                     join::JoinType::Inner => logical_expr::JoinType::Inner,
                     join::JoinType::Left => logical_expr::JoinType::Left,
+                    join::JoinType::Single => {
+                        return Err(DataFusionError::NotImplemented(
+                            "single join is not supported in datafusion physical planning"
+                                .to_string(),
+                        ));
+                    }
+                    join::JoinType::Mark(_) => {
+                        return Err(DataFusionError::NotImplemented(
+                            "mark join is not supported in datafusion physical planning"
+                                .to_string(),
+                        ));
+                    }
                 };
                 let build_side_dfschema =
                     from_optd_schema(&join.build_side().output_schema(ctx).unwrap());

--- a/optd/core/src/ir/column/set.rs
+++ b/optd/core/src/ir/column/set.rs
@@ -24,6 +24,11 @@ impl ColumnSet {
     pub fn with_capacity(n: usize) -> Self {
         Self(HashSet::with_capacity(n))
     }
+
+    pub fn iter(&self) -> impl Iterator<Item = &Column> {
+        self.0.iter()
+    }
+
     pub fn contains(&self, column: &Column) -> bool {
         self.0.contains(column)
     }

--- a/optd/core/src/ir/operator/logical/mod.rs
+++ b/optd/core/src/ir/operator/logical/mod.rs
@@ -4,9 +4,11 @@
 //! aggregating data.
 
 pub mod aggregate;
+pub mod dependent_join;
 pub mod get;
 pub mod join;
 pub mod order_by;
 pub mod project;
 pub mod remap;
 pub mod select;
+pub mod subquery;

--- a/optd/core/src/ir/operator/logical/subquery.rs
+++ b/optd/core/src/ir/operator/logical/subquery.rs
@@ -1,0 +1,46 @@
+//! The subquery operator is used to represent subqueries in logical plans.
+
+use crate::ir::{
+    IRCommon, Operator,
+    explain::Explain,
+    macros::{define_node, impl_operator_conversion},
+    properties::OperatorProperties,
+};
+use pretty_xmlish::Pretty;
+use std::sync::Arc;
+
+define_node!(
+    /// Metadata: (none)
+    /// Scalars: (none)
+    LogicalSubquery, LogicalSubqueryBorrowed {
+        properties: OperatorProperties,
+        metadata: LogicalSubqueryMetadata {},
+        inputs: {
+            operators: [input],
+            scalars: [],
+        }
+    }
+);
+impl_operator_conversion!(LogicalSubquery, LogicalSubqueryBorrowed);
+
+impl LogicalSubquery {
+    pub fn new(input: Arc<Operator>) -> Self {
+        Self {
+            meta: LogicalSubqueryMetadata {},
+            common: IRCommon::with_input_operators_only(Arc::new([input])),
+        }
+    }
+}
+
+impl Explain for LogicalSubqueryBorrowed<'_> {
+    fn explain<'a>(
+        &self,
+        ctx: &crate::ir::IRContext,
+        option: &crate::ir::explain::ExplainOption,
+    ) -> pretty_xmlish::Pretty<'a> {
+        let mut fields = Vec::new();
+        fields.extend(self.common.explain_operator_properties(ctx, option));
+        let children = self.common.explain_input_operators(ctx, option);
+        Pretty::simple_record("LogicalSubquery", fields, children)
+    }
+}

--- a/optd/core/src/ir/properties/output_schema.rs
+++ b/optd/core/src/ir/properties/output_schema.rs
@@ -75,28 +75,28 @@ impl Derive<OutputSchema> for crate::ir::Operator {
                         let mut columns = join
                             .outer()
                             .output_schema(ctx)?
-                            .columns()
+                            .fields()
                             .iter()
                             .cloned()
                             .collect_vec();
                         let mark_meta = ctx.get_column_meta(mark_column);
                         columns.push(Arc::new(Field::new(
                             mark_meta.name.clone(),
-                            mark_meta.data_type,
+                            mark_meta.data_type.clone(),
                             true,
                         )));
-                        Some(Schema::new(columns))
+                        Ok(Schema::new(columns))
                     }
                     _ => {
                         let columns = join
                             .outer()
                             .output_schema(ctx)?
-                            .columns()
+                            .fields()
                             .iter()
-                            .chain(join.inner().output_schema(ctx)?.columns().iter())
+                            .chain(join.inner().output_schema(ctx)?.fields().iter())
                             .cloned()
                             .collect_vec();
-                        Some(Schema::new(columns))
+                        Ok(Schema::new(columns))
                     }
                 }
             }
@@ -107,28 +107,28 @@ impl Derive<OutputSchema> for crate::ir::Operator {
                         let mut columns = join
                             .outer()
                             .output_schema(ctx)?
-                            .columns()
+                            .fields()
                             .iter()
                             .cloned()
                             .collect_vec();
                         let mark_meta = ctx.get_column_meta(mark_column);
                         columns.push(Arc::new(Field::new(
                             mark_meta.name.clone(),
-                            mark_meta.data_type,
+                            mark_meta.data_type.clone(),
                             true,
                         )));
-                        Some(Schema::new(columns))
+                        Ok(Schema::new(columns))
                     }
                     _ => {
                         let columns = join
                             .outer()
                             .output_schema(ctx)?
-                            .columns()
+                            .fields()
                             .iter()
-                            .chain(join.inner().output_schema(ctx)?.columns().iter())
+                            .chain(join.inner().output_schema(ctx)?.fields().iter())
                             .cloned()
                             .collect_vec();
-                        Some(Schema::new(columns))
+                        Ok(Schema::new(columns))
                     }
                 }
             }

--- a/optd/core/src/ir/properties/output_schema.rs
+++ b/optd/core/src/ir/properties/output_schema.rs
@@ -259,7 +259,7 @@ fn compute_join_schema(
             .iter()
             .cloned()
             .chain(inner_schema.fields().iter().cloned())
-            .chain(mark_field.into_iter())
+            .chain(mark_field)
             .collect_vec(),
     ))
 }

--- a/optd/core/src/ir/properties/tuple_ordering.rs
+++ b/optd/core/src/ir/properties/tuple_ordering.rs
@@ -167,10 +167,12 @@ impl crate::ir::properties::TrySatisfy<TupleOrdering> for Operator {
             OperatorKind::Group(_) => None,
             OperatorKind::LogicalGet(_)
             | OperatorKind::LogicalJoin(_)
+            | OperatorKind::LogicalDependentJoin(_)
             | OperatorKind::LogicalProject(_)
             | OperatorKind::LogicalSelect(_)
             | OperatorKind::LogicalOrderBy(_)
-            | OperatorKind::LogicalAggregate(_) => {
+            | OperatorKind::LogicalAggregate(_)
+            | OperatorKind::LogicalSubquery(_) => {
                 assert_eq!(self.kind.category(), OperatorCategory::Logical);
                 None
             }

--- a/optd/core/src/magic/card.rs
+++ b/optd/core/src/magic/card.rs
@@ -1,7 +1,7 @@
 use crate::ir::{
     Operator, Scalar,
-    operator::*,
     operator::join::JoinType,
+    operator::*,
     properties::{Cardinality, CardinalityEstimator},
     scalar::*,
 };
@@ -32,25 +32,23 @@ impl CardinalityEstimator for MagicCardinalityEstimator {
                 Self::MAGIC_JOIN_COND_SELECTIVITY
             }
         };
-        let estimate_join = |join_type: &JoinType,
-                             outer: &Operator,
-                             inner: &Operator,
-                             join_cond: &Scalar| {
-            let left_card = outer.cardinality(ctx);
-            let right_card = inner.cardinality(ctx);
-            match *join_type {
-                JoinType::Mark(_) => left_card,
-                JoinType::Single => {
-                    let selectivity = join_selectivity(join_cond);
-                    (selectivity * left_card * right_card)
-                        .map(|value| value.min(left_card.as_f64()))
+        let estimate_join =
+            |join_type: &JoinType, outer: &Operator, inner: &Operator, join_cond: &Scalar| {
+                let left_card = outer.cardinality(ctx);
+                let right_card = inner.cardinality(ctx);
+                match *join_type {
+                    JoinType::Mark(_) => left_card,
+                    JoinType::Single => {
+                        let selectivity = join_selectivity(join_cond);
+                        (selectivity * left_card * right_card)
+                            .map(|value| value.min(left_card.as_f64()))
+                    }
+                    _ => {
+                        let selectivity = join_selectivity(join_cond);
+                        selectivity * left_card * right_card
+                    }
                 }
-                _ => {
-                    let selectivity = join_selectivity(join_cond);
-                    selectivity * left_card * right_card
-                }
-            }
-        };
+            };
         match &op.kind {
             OperatorKind::Group(_) => {
                 // Relies on the normalized expression's cardinality estimation.

--- a/optd/core/src/magic/cm.rs
+++ b/optd/core/src/magic/cm.rs
@@ -21,10 +21,12 @@ impl CostModel for MagicCostModel {
             OperatorKind::Group(_) => None,
             OperatorKind::LogicalGet(_) => None,
             OperatorKind::LogicalJoin(_) => None,
+            OperatorKind::LogicalDependentJoin(_) => None,
             OperatorKind::LogicalSelect(_) => None,
             OperatorKind::LogicalProject(_) => None,
             OperatorKind::LogicalAggregate(_) => None,
             OperatorKind::LogicalOrderBy(_) => None,
+            OperatorKind::LogicalSubquery(_) => None,
             OperatorKind::LogicalRemap(_) => Some(Cost::UNIT),
             OperatorKind::EnforcerSort(_) => {
                 let input_card = op.input_operators()[0].cardinality(ctx);

--- a/optd/core/src/rules/implementations/hash_join.rs
+++ b/optd/core/src/rules/implementations/hash_join.rs
@@ -6,7 +6,7 @@ use crate::ir::{
     Column, IRContext, OperatorKind, Scalar,
     builder::boolean,
     convert::IntoScalar,
-    operator::{LogicalJoin, LogicalJoinBorrowed},
+    operator::{LogicalJoin, LogicalJoinBorrowed, join::JoinType},
     rule::{OperatorPattern, Rule},
     scalar::{BinaryOp, BinaryOpBorrowed, ColumnRef, NaryOp, NaryOpKind},
 };
@@ -25,8 +25,13 @@ type SplittedJoinConds = (Vec<(Column, Column)>, Vec<Arc<Scalar>>);
 
 impl LogicalJoinAsPhysicalHashJoinRule {
     pub fn new() -> Self {
-        let pattern =
-            OperatorPattern::with_top_matches(|kind| matches!(kind, OperatorKind::LogicalJoin(_)));
+        let pattern = OperatorPattern::with_top_matches(|kind| {
+            matches!(
+                kind,
+                OperatorKind::LogicalJoin(meta)
+                    if matches!(meta.join_type, JoinType::Inner | JoinType::Left)
+            )
+        });
         Self { pattern }
     }
 

--- a/optd/core/src/rules/implementations/nl_join.rs
+++ b/optd/core/src/rules/implementations/nl_join.rs
@@ -1,7 +1,7 @@
 use crate::ir::{
     OperatorKind,
     convert::IntoOperator,
-    operator::{LogicalJoin, PhysicalNLJoin},
+    operator::{LogicalJoin, PhysicalNLJoin, join::JoinType},
     rule::{OperatorPattern, Rule},
 };
 
@@ -17,8 +17,13 @@ impl Default for LogicalJoinAsPhysicalNLJoinRule {
 
 impl LogicalJoinAsPhysicalNLJoinRule {
     pub fn new() -> Self {
-        let pattern =
-            OperatorPattern::with_top_matches(|kind| matches!(kind, OperatorKind::LogicalJoin(_)));
+        let pattern = OperatorPattern::with_top_matches(|kind| {
+            matches!(
+                kind,
+                OperatorKind::LogicalJoin(meta)
+                    if matches!(meta.join_type, JoinType::Inner | JoinType::Left)
+            )
+        });
         Self { pattern }
     }
 }

--- a/optd/core/src/rules/logical_select_join_transpose.rs
+++ b/optd/core/src/rules/logical_select_join_transpose.rs
@@ -1,6 +1,6 @@
 use crate::ir::{
     IRContext, OperatorKind,
-    operator::{LogicalJoin, LogicalSelect},
+    operator::{LogicalJoin, LogicalSelect, join::JoinType},
     rule::{OperatorPattern, Rule},
 };
 
@@ -22,7 +22,13 @@ impl LogicalSelectJoinTransposeRule {
         });
         pattern.add_input_operator_pattern(
             INPUT,
-            OperatorPattern::with_top_matches(|kind| matches!(kind, OperatorKind::LogicalJoin(_))),
+            OperatorPattern::with_top_matches(|kind| {
+                matches!(
+                    kind,
+                    OperatorKind::LogicalJoin(meta)
+                        if matches!(meta.join_type, JoinType::Inner | JoinType::Left)
+                )
+            }),
         );
         Self { pattern }
     }


### PR DESCRIPTION
## Problem

There is no way to currently represent subqueries.

## Summary of changes

Added a subquery node (to be decorrelated), as well as the 3 major decorrelated join nodes. All of these are logical only, since the goal is to convert a logical subquery node into one of these 3 logical join nodes during unnesting.

- New join types `Single` and `Mark`
- New `LogicalDependentJoin` node