### PR TITLE
Refactor statistics types into core and add column-level stats support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3636,6 +3636,7 @@ version = "0.1.0"
 dependencies = [
  "duckdb",
  "futures",
+ "optd-core",
  "serde",
  "serde_json",
  "snafu",
@@ -3676,6 +3677,8 @@ dependencies = [
  "console-subscriber",
  "itertools",
  "pretty-xmlish",
+ "serde",
+ "serde_json",
  "snafu",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3655,6 +3655,7 @@ dependencies = [
  "futures",
  "object_store",
  "optd-catalog",
+ "optd-core",
  "optd-datafusion",
  "parquet",
  "regex",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -28,6 +28,7 @@ futures = "0.3.31"
 optd-catalog = { path = "../optd/catalog", version = "0.1" }
 parquet = "57.2"
 serde_json = "1"
+optd-core = { version = "0.1.0", path = "../optd/core" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/cli/src/auto_stats.rs
+++ b/cli/src/auto_stats.rs
@@ -5,7 +5,7 @@
 //! for CSV/JSON files. Behavior is configurable via environment variables.
 
 use datafusion::common::{DataFusionError, Result};
-use optd_catalog::TableStatistics;
+use optd_core::ir::statistics::{ColumnStatistics, TableStatistics};
 use std::path::Path;
 
 /// Configuration for automatic statistics computation
@@ -127,7 +127,7 @@ async fn extract_parquet_statistics(location: &str) -> Result<Option<TableStatis
 /// Aggregates min/max/null_count across all row groups for each column.
 fn extract_column_statistics_from_parquet(
     metadata: &parquet::file::metadata::ParquetMetaData,
-) -> Result<Vec<optd_catalog::ColumnStatistics>> {
+) -> Result<Vec<ColumnStatistics>> {
     let schema = metadata.file_metadata().schema_descr();
     let num_row_groups = metadata.num_row_groups();
     let mut column_statistics = Vec::new();
@@ -174,7 +174,7 @@ fn extract_column_statistics_from_parquet(
             }
         }
 
-        column_statistics.push(optd_catalog::ColumnStatistics {
+        column_statistics.push(ColumnStatistics {
             column_id: 0, // External tables don't have column IDs
             column_type: col_type,
             name: col_name,

--- a/connectors/datafusion/src/planner.rs
+++ b/connectors/datafusion/src/planner.rs
@@ -743,25 +743,27 @@ impl OptdQueryPlanner {
                         row_count,
                         size_bytes,
                         column_statistics: column_statistics
-                        .iter()
-                        .enumerate()
-                        .map(|(index, column_stat)| {
-                            let column = Column(first_column.0 + index);
-                            let column_meta = ctx.get_column_meta(&column);
+                            .iter()
+                            .enumerate()
+                            .map(|(index, column_stat)| {
+                                let column = Column(first_column.0 + index);
+                                let column_meta = ctx.get_column_meta(&column);
 
-                            ColumnStatistics {
-                                column_id: column.0 as i64,
-                                column_type: format!("{:?}", column_meta.data_type),
-                                name: column_meta.name.clone(),
-                                // TODO(Aditya): populate with stuff from HLL, digests, etc.
-                                advanced_stats: Vec::new(),
-                                min_value: precision_to_string(&column_stat.min_value),
-                                max_value: precision_to_string(&column_stat.max_value),
-                                null_count: precision_to_option(&column_stat.null_count),
-                                distinct_count: precision_to_option(&column_stat.distinct_count),
-                            }
-                        })
-                        .collect(),
+                                ColumnStatistics {
+                                    column_id: column.0 as i64,
+                                    column_type: format!("{:?}", column_meta.data_type),
+                                    name: column_meta.name.clone(),
+                                    // TODO(Aditya): populate with stuff from HLL, digests, etc.
+                                    advanced_stats: Vec::new(),
+                                    min_value: precision_to_string(&column_stat.min_value),
+                                    max_value: precision_to_string(&column_stat.max_value),
+                                    null_count: precision_to_option(&column_stat.null_count),
+                                    distinct_count: precision_to_option(
+                                        &column_stat.distinct_count,
+                                    ),
+                                }
+                            })
+                            .collect(),
                     }
                 })
                 .unwrap_or_else(|_| TableStatistics {

--- a/connectors/datafusion/src/planner.rs
+++ b/connectors/datafusion/src/planner.rs
@@ -36,7 +36,7 @@ use optd_core::{
     connector_err,
     error::Result as OptdResult,
     ir::{
-        IRContext, Scalar,
+        Column, IRContext, Scalar,
         builder::{self as optd_builder, column_assign, column_ref, list, literal},
         catalog::{Field, Schema},
         convert::{IntoOperator, IntoScalar},
@@ -51,6 +51,7 @@ use optd_core::{
             BinaryOp, Cast, ColumnAssign, ColumnRef, Function, FunctionKind, Like, List, NaryOp,
             NaryOpKind,
         },
+        statistics::{ColumnStatistics, TableStatistics},
     },
     rules,
 };
@@ -61,6 +62,8 @@ use crate::{
     OptdExtensionConfig,
     value::{from_optd_value, try_into_optd_value},
 };
+
+const DEFAULT_ROW_COUNT: usize = 1000;
 
 #[derive(Default)]
 pub struct OptdQueryPlanner {
@@ -81,6 +84,41 @@ fn tuple_err<T, R>(
         (Err(e), Ok(_)) => Err(e),
         (Ok(_), Err(e1)) => Err(e1),
         (Err(e), Err(_)) => Err(e),
+    }
+}
+
+/// Extract value from Precision, returning default if Absent.
+fn precision_value_or<T: Copy + PartialOrd + Eq + std::fmt::Debug>(
+    precision: datafusion::common::stats::Precision<T>,
+    default: T,
+) -> T {
+    match precision {
+        datafusion::common::stats::Precision::Exact(v) => v,
+        datafusion::common::stats::Precision::Inexact(v) => v,
+        datafusion::common::stats::Precision::Absent => default,
+    }
+}
+
+/// Extract value from Precision as Option.
+fn precision_to_option<T: Copy + PartialOrd + Eq + std::fmt::Debug>(
+    precision: &datafusion::common::stats::Precision<T>,
+) -> Option<T> {
+    match precision {
+        datafusion::common::stats::Precision::Exact(v) => Some(*v),
+        datafusion::common::stats::Precision::Inexact(v) => Some(*v),
+        datafusion::common::stats::Precision::Absent => None,
+    }
+}
+
+/// Extract value from Precision as Option<String>.
+/// TODO(Aditya): this should not be required after we move from `String` to `Value`.
+fn precision_to_string<T: ToString + PartialOrd + Eq + Clone + std::fmt::Debug>(
+    precision: &datafusion::common::stats::Precision<T>,
+) -> Option<String> {
+    match precision {
+        datafusion::common::stats::Precision::Exact(v) => Some(v.to_string()),
+        datafusion::common::stats::Precision::Inexact(v) => Some(v.to_string()),
+        datafusion::common::stats::Precision::Absent => None,
     }
 }
 
@@ -684,7 +722,7 @@ impl OptdQueryPlanner {
             .cat
             .try_create_table(table_name, schema.clone())
             .unwrap_or_else(|existing| existing);
-        ctx.add_base_table_columns(source, &schema);
+        let first_column = ctx.add_base_table_columns(source, &schema);
 
         let provider = source_as_provider(&node.source).unwrap();
         let exec = provider
@@ -692,16 +730,48 @@ impl OptdQueryPlanner {
             .await
             .unwrap();
 
-        ctx.cat.set_table_row_count(
+        ctx.cat.set_table_stats(
             source,
             exec.partition_statistics(None)
-                .map(|x| match x.num_rows {
-                    datafusion::common::stats::Precision::Exact(x) => x,
-                    datafusion::common::stats::Precision::Inexact(x) => x,
-                    datafusion::common::stats::Precision::Absent => 1000,
+                .map(|statistics| {
+                    let column_statistics = statistics.column_statistics;
+
+                    let row_count = precision_value_or(statistics.num_rows, DEFAULT_ROW_COUNT);
+                    let size_bytes = precision_to_option(&statistics.total_byte_size);
+
+                    TableStatistics {
+                        row_count,
+                        size_bytes,
+                        column_statistics: column_statistics
+                        .iter()
+                        .enumerate()
+                        .map(|(index, column_stat)| {
+                            let column = Column(first_column.0 + index);
+                            let column_meta = ctx.get_column_meta(&column);
+
+                            ColumnStatistics {
+                                column_id: column.0 as i64,
+                                column_type: format!("{:?}", column_meta.data_type),
+                                name: column_meta.name.clone(),
+                                // TODO(Aditya): populate with stuff from HLL, digests, etc.
+                                advanced_stats: Vec::new(),
+                                min_value: precision_to_string(&column_stat.min_value),
+                                max_value: precision_to_string(&column_stat.max_value),
+                                null_count: precision_to_option(&column_stat.null_count),
+                                distinct_count: precision_to_option(&column_stat.distinct_count),
+                            }
+                        })
+                        .collect(),
+                    }
                 })
-                .unwrap_or(1000),
+                .unwrap_or_else(|_| TableStatistics {
+                    row_count: DEFAULT_ROW_COUNT,
+                    size_bytes: None,
+                    // TODO(Aditya): add some default column stats?
+                    column_statistics: vec![],
+                }),
         );
+
         let mut projections = node
             .projection
             .as_ref()

--- a/optd/catalog/Cargo.toml
+++ b/optd/catalog/Cargo.toml
@@ -10,6 +10,7 @@ duckdb = { version = "1.4.3", features = ["bundled"] }
 snafu = { workspace = true }
 serde_json = "1.0"
 tokio = { workspace = true, features = ["sync", "rt-multi-thread"] }
+optd-core = { version = "0.1.0", path = "../core" }
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/optd/catalog/src/lib.rs
+++ b/optd/catalog/src/lib.rs
@@ -5,6 +5,7 @@ use duckdb::{
     types::Null,
 };
 
+use optd_core::ir::statistics::{ColumnStatistics, TableStatistics, AdvanceColumnStatistics};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use snafu::{ResultExt, prelude::*};
@@ -179,7 +180,7 @@ const CREATE_EXTRA_TABLES_QUERY: &str = r#"
         PRIMARY KEY (table_id, option_key)
     );
 
-    CREATE INDEX IF NOT EXISTS idx_optd_external_table_schema 
+    CREATE INDEX IF NOT EXISTS idx_optd_external_table_schema
         ON __ducklake_metadata_metalake.main.optd_external_table(schema_id, table_name, end_snapshot);
 
     CREATE INDEX IF NOT EXISTS idx_optd_external_table_snapshot
@@ -214,14 +215,14 @@ const UPDATE_ADV_STATS_QUERY: &str = r#"
 /// SQL to insert advanced statistics entry
 const INSERT_ADV_STATS_QUERY: &str = r#"
     INSERT INTO __ducklake_metadata_metalake.main.ducklake_table_column_adv_stats
-        (column_id, begin_snapshot, end_snapshot, table_id, stats_type, payload) 
+        (column_id, begin_snapshot, end_snapshot, table_id, stats_type, payload)
     VALUES (?, ?, ?, ?, ?, ?);
 "#;
 
 /// SQL to insert snapshot record
 const INSERT_SNAPSHOT_QUERY: &str = r#"
     INSERT INTO __ducklake_metadata_metalake.main.ducklake_snapshot
-        (snapshot_id, snapshot_time, schema_version, next_catalog_id, next_file_id) 
+        (snapshot_id, snapshot_time, schema_version, next_catalog_id, next_file_id)
     VALUES (?, NOW(), ?, ?, ?);
 "#;
 
@@ -286,122 +287,54 @@ struct TableColumnStatisticsEntry {
     payload: Option<String>,
 }
 
-/// Table statistics (row count + column stats)
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TableStatistics {
-    pub row_count: usize,
-    pub column_statistics: Vec<ColumnStatistics>,
+fn table_statistics_from_entries(
+    entries: Vec<TableColumnStatisticsEntry>,
+) -> TableStatistics {
+    let mut row_flag = false;
+    let mut row_count = 0;
+    let mut column_statistics = Vec::new();
 
-    /// File size in bytes
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub size_bytes: Option<usize>,
-}
-
-impl FromIterator<Result<TableColumnStatisticsEntry, Error>> for TableStatistics {
-    fn from_iter<T: IntoIterator<Item = Result<TableColumnStatisticsEntry, Error>>>(
-        iter: T,
-    ) -> Self {
-        let mut row_flag = false;
-        let mut row_count = 0;
-        let mut column_statistics = Vec::new();
-
-        // Stats will be ordered by table_id then column_id
-        for e in iter.into_iter().flatten() {
-            // Check if unique table/column combination
-            if column_statistics
-                .last()
-                .is_none_or(|last: &ColumnStatistics| last.column_id != e.column_id)
-            {
-                // New column encountered
-                column_statistics.push(ColumnStatistics::new(
-                    e.column_id,
-                    e.column_type.clone(),
-                    e.column_name.clone(),
-                    Vec::new(),
-                ));
-            }
-
-            assert!(
-                !column_statistics.is_empty()
-                    && column_statistics.last().unwrap().column_id == e.column_id,
-                "Column statistics should not be empty and last column_id should match current column_id"
-            );
-
-            if let Some(last_column_stat) = column_statistics.last_mut()
-                && let (Some(stats_type), Some(payload)) = (e.stats_type, e.payload)
-            {
-                let data = serde_json::from_str(&payload).unwrap_or(Value::Null);
-                last_column_stat.add_advanced_stat(AdvanceColumnStatistics { stats_type, data });
-            }
-
-            // Assuming all columns have the same record_count, only need to set once
-            if !row_flag {
-                row_count = e.record_count as usize;
-                row_flag = true;
-            }
+    // Stats will be ordered by table_id then column_id
+    for e in entries.into_iter() {
+        // Check if unique table/column combination
+        if column_statistics
+            .last()
+            .is_none_or(|last: &ColumnStatistics| last.column_id != e.column_id)
+        {
+            // New column encountered
+            column_statistics.push(ColumnStatistics::new(
+                e.column_id,
+                e.column_type.clone(),
+                e.column_name.clone(),
+                Vec::new(),
+            ));
         }
 
-        TableStatistics {
-            row_count,
-            column_statistics,
-            size_bytes: None, // Not populated from database queries
+        assert!(
+            !column_statistics.is_empty()
+                && column_statistics.last().unwrap().column_id == e.column_id,
+            "Column statistics should not be empty and last column_id should match current column_id"
+        );
+
+        if let Some(last_column_stat) = column_statistics.last_mut()
+            && let (Some(stats_type), Some(payload)) = (e.stats_type, e.payload)
+        {
+            let data = serde_json::from_str(&payload).unwrap_or(Value::Null);
+            last_column_stat.add_advanced_stat(AdvanceColumnStatistics { stats_type, data });
         }
-    }
-}
 
-/// Column statistics (external tables use column_id=0, name for identification)
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ColumnStatistics {
-    pub column_id: i64,
-    pub column_type: String,
-    pub name: String,
-    pub advanced_stats: Vec<AdvanceColumnStatistics>,
-
-    /// Minimum value in the column (serialized as JSON string)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub min_value: Option<String>,
-    /// Maximum value in the column (serialized as JSON string)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_value: Option<String>,
-    /// Total number of null values
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub null_count: Option<usize>,
-    /// Number of distinct values (NDV)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub distinct_count: Option<usize>,
-}
-
-impl ColumnStatistics {
-    fn new(
-        column_id: i64,
-        column_type: String,
-        name: String,
-        advanced_stats: Vec<AdvanceColumnStatistics>,
-    ) -> Self {
-        Self {
-            column_id,
-            column_type,
-            name,
-            advanced_stats,
-            min_value: None,
-            max_value: None,
-            null_count: None,
-            distinct_count: None,
+        // Assuming all columns have the same record_count, only need to set once
+        if !row_flag {
+            row_count = e.record_count as usize;
+            row_flag = true;
         }
     }
 
-    fn add_advanced_stat(&mut self, stat: AdvanceColumnStatistics) {
-        self.advanced_stats.push(stat);
+    TableStatistics {
+        row_count,
+        column_statistics,
+        size_bytes: None, // Not populated from database queries
     }
-}
-
-/// An advanced statistics entry with type and serialized data at a snapshot.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AdvanceColumnStatistics {
-    /// Type of the statistical summaries (e.g., histogram, distinct count).
-    pub stats_type: String,
-    /// Serialized data for the statistics at a snapshot.
-    pub data: Value,
 }
 
 /// Identifier for a snapshot in the statistics database.
@@ -789,7 +722,7 @@ impl DuckLakeCatalog {
                 WHERE schema_id = ? AND table_name = ?
                 UNION ALL
                 SELECT table_id, 0 as is_internal FROM __ducklake_metadata_metalake.main.optd_external_table
-                WHERE schema_id = ? AND table_name = ? 
+                WHERE schema_id = ? AND table_name = ?
                   AND begin_snapshot <= ?
                   AND (end_snapshot IS NULL OR end_snapshot > ?)
                 LIMIT 1
@@ -880,8 +813,8 @@ impl DuckLakeCatalog {
                 r#"
                 SELECT column_id, stats_type, payload
                 FROM __ducklake_metadata_metalake.main.ducklake_table_column_adv_stats
-                WHERE table_id = ? 
-                  AND ? >= begin_snapshot 
+                WHERE table_id = ?
+                  AND ? >= begin_snapshot
                   AND (? < end_snapshot OR end_snapshot IS NULL)
                 ORDER BY column_id, stats_type
                 "#,
@@ -1020,8 +953,8 @@ impl DuckLakeCatalog {
             }
         }
 
-        // Convert entries to TableStatistics using FromIterator
-        let mut result = TableStatistics::from_iter(entries.into_iter().map(Ok));
+        // Convert entries to TableStatistics
+        let mut result = table_statistics_from_entries(entries);
 
         // For internal tables, ensure ALL columns are included (even those without stats)
         if is_internal_table {
@@ -1309,7 +1242,7 @@ impl DuckLakeCatalog {
                 let mut stmt = conn
                     .prepare(
                         r#"
-                        SELECT table_id, schema_id, table_name, location, file_format, 
+                        SELECT table_id, schema_id, table_name, location, file_format,
                                compression, begin_snapshot, end_snapshot
                         FROM __ducklake_metadata_metalake.main.optd_external_table
                         WHERE schema_id = ? AND table_name = ? AND end_snapshot IS NULL
@@ -1341,10 +1274,10 @@ impl DuckLakeCatalog {
                 let mut stmt = conn
                     .prepare(
                         r#"
-                        SELECT table_id, schema_id, table_name, location, file_format, 
+                        SELECT table_id, schema_id, table_name, location, file_format,
                                compression, begin_snapshot, end_snapshot
                         FROM __ducklake_metadata_metalake.main.optd_external_table
-                        WHERE schema_id = ? AND table_name = ? 
+                        WHERE schema_id = ? AND table_name = ?
                           AND begin_snapshot <= ?
                           AND (end_snapshot IS NULL OR end_snapshot > ?)
                         "#,
@@ -1487,7 +1420,7 @@ impl DuckLakeCatalog {
                         SELECT table_id, schema_id, table_name, location, file_format,
                                compression, begin_snapshot, end_snapshot
                         FROM __ducklake_metadata_metalake.main.optd_external_table
-                        WHERE schema_id = ? 
+                        WHERE schema_id = ?
                           AND begin_snapshot <= ?
                           AND (end_snapshot IS NULL OR end_snapshot > ?)
                         ORDER BY table_name
@@ -1725,7 +1658,7 @@ impl DuckLakeCatalog {
         let has_existing_stats: i64 = conn
             .prepare(
                 r#"
-                SELECT COUNT(*) 
+                SELECT COUNT(*)
                 FROM __ducklake_metadata_metalake.main.ducklake_table_stats
                 WHERE table_id = ? AND record_count IS NOT NULL
                 "#,

--- a/optd/catalog/src/lib.rs
+++ b/optd/catalog/src/lib.rs
@@ -5,7 +5,7 @@ use duckdb::{
     types::Null,
 };
 
-use optd_core::ir::statistics::{ColumnStatistics, TableStatistics, AdvanceColumnStatistics};
+use optd_core::ir::statistics::{AdvanceColumnStatistics, ColumnStatistics, TableStatistics};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use snafu::{ResultExt, prelude::*};
@@ -287,9 +287,7 @@ struct TableColumnStatisticsEntry {
     payload: Option<String>,
 }
 
-fn table_statistics_from_entries(
-    entries: Vec<TableColumnStatisticsEntry>,
-) -> TableStatistics {
+fn table_statistics_from_entries(entries: Vec<TableColumnStatisticsEntry>) -> TableStatistics {
     let mut row_flag = false;
     let mut row_count = 0;
     let mut column_statistics = Vec::new();

--- a/optd/catalog/tests/catalog_error_tests.rs
+++ b/optd/catalog/tests/catalog_error_tests.rs
@@ -350,7 +350,8 @@ async fn test_invalid_compression_types() {
 
 #[tokio::test]
 async fn test_invalid_statistics_json() {
-    use optd_catalog::{RegisterTableRequest, TableStatistics};
+    use optd_catalog::{RegisterTableRequest};
+    use optd_core::ir::statistics::TableStatistics;
     use std::collections::HashMap;
 
     let (_temp_dir, service, handle) = create_test_service();
@@ -528,7 +529,8 @@ async fn test_concurrent_catalog_modifications() {
 
 #[tokio::test]
 async fn test_concurrent_statistics_updates() {
-    use optd_catalog::{RegisterTableRequest, TableStatistics};
+    use optd_catalog::{RegisterTableRequest};
+    use optd_core::ir::statistics::TableStatistics;
     use std::collections::HashMap;
     use std::sync::Arc;
     use tokio::sync::Barrier;

--- a/optd/catalog/tests/catalog_error_tests.rs
+++ b/optd/catalog/tests/catalog_error_tests.rs
@@ -350,7 +350,7 @@ async fn test_invalid_compression_types() {
 
 #[tokio::test]
 async fn test_invalid_statistics_json() {
-    use optd_catalog::{RegisterTableRequest};
+    use optd_catalog::RegisterTableRequest;
     use optd_core::ir::statistics::TableStatistics;
     use std::collections::HashMap;
 
@@ -529,7 +529,7 @@ async fn test_concurrent_catalog_modifications() {
 
 #[tokio::test]
 async fn test_concurrent_statistics_updates() {
-    use optd_catalog::{RegisterTableRequest};
+    use optd_catalog::RegisterTableRequest;
     use optd_core::ir::statistics::TableStatistics;
     use std::collections::HashMap;
     use std::sync::Arc;

--- a/optd/catalog/tests/statistics_tests.rs
+++ b/optd/catalog/tests/statistics_tests.rs
@@ -2,10 +2,7 @@
 //! Covers snapshot versioning, time-travel queries, and edge cases.
 #![cfg(not(target_os = "windows"))]
 
-use optd_catalog::{
-Catalog, DuckLakeCatalog, RegisterTableRequest,
-    SnapshotId
-};
+use optd_catalog::{Catalog, DuckLakeCatalog, RegisterTableRequest, SnapshotId};
 use optd_core::ir::statistics::{AdvanceColumnStatistics, ColumnStatistics, TableStatistics};
 
 use serde_json::json;

--- a/optd/catalog/tests/statistics_tests.rs
+++ b/optd/catalog/tests/statistics_tests.rs
@@ -3,9 +3,11 @@
 #![cfg(not(target_os = "windows"))]
 
 use optd_catalog::{
-    AdvanceColumnStatistics, Catalog, ColumnStatistics, DuckLakeCatalog, RegisterTableRequest,
-    SnapshotId, TableStatistics,
+Catalog, DuckLakeCatalog, RegisterTableRequest,
+    SnapshotId
 };
+use optd_core::ir::statistics::{AdvanceColumnStatistics, ColumnStatistics, TableStatistics};
+
 use serde_json::json;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/optd/core/Cargo.toml
+++ b/optd/core/Cargo.toml
@@ -21,6 +21,8 @@ tokio = { workspace = true, features = [
 tracing = { workspace = true }
 arrow-schema = { workspace = true }
 chrono = { workspace = true }
+serde = "1.0.228"
+serde_json = "1.0.149"
 
 [dev-dependencies]
 console-subscriber = "0.4.1"

--- a/optd/core/Cargo.toml
+++ b/optd/core/Cargo.toml
@@ -21,7 +21,7 @@ tokio = { workspace = true, features = [
 tracing = { workspace = true }
 arrow-schema = { workspace = true }
 chrono = { workspace = true }
-serde = "1.0.228"
+serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 
 [dev-dependencies]

--- a/optd/core/src/error.rs
+++ b/optd/core/src/error.rs
@@ -8,7 +8,7 @@ pub enum Error {
     Whatever {
         /// The error message.
         message: String,
-        /// The underying error.
+        /// The underlying error.
         #[snafu(source(from(Box<dyn std::error::Error + Send + Sync>, Some)))]
         source: Option<Box<dyn std::error::Error + Send + Sync>>,
     },

--- a/optd/core/src/ir/catalog.rs
+++ b/optd/core/src/ir/catalog.rs
@@ -5,6 +5,8 @@ pub use arrow_schema::Field;
 pub use arrow_schema::Schema;
 pub use arrow_schema::SchemaRef;
 
+use crate::ir::statistics::TableStatistics;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct DataSourceId(pub i64);
 
@@ -14,7 +16,7 @@ pub struct TableMetadata {
     pub id: DataSourceId,
     pub name: String,
     pub schema: SchemaRef,
-    pub row_count: usize,
+    pub stats: Option<TableStatistics>,
 }
 
 pub trait Catalog: Send + Sync + 'static {
@@ -24,11 +26,20 @@ pub trait Catalog: Send + Sync + 'static {
         table_name: String,
         schema: SchemaRef,
     ) -> Result<DataSourceId, DataSourceId>;
+
+    /// Creates a table with stats.
+    fn try_create_table_with_stats(
+        &self,
+        table_name: String,
+        schema: SchemaRef,
+        stats: TableStatistics,
+    ) -> Result<DataSourceId, DataSourceId>;
+
     /// Describes the schema of a table with identifier `table_id`.
     fn describe_table(&self, table_id: DataSourceId) -> TableMetadata;
     /// Describes the schema of a table with name `table_name`.
     fn try_describe_table_with_name(&self, table_name: &str) -> anyhow::Result<TableMetadata>;
 
     /// TODO(yuchen): This is a mock.
-    fn set_table_row_count(&self, table_id: DataSourceId, row_count: usize);
+    fn set_table_stats(&self, table_id: DataSourceId, stats: TableStatistics);
 }

--- a/optd/core/src/ir/mod.rs
+++ b/optd/core/src/ir/mod.rs
@@ -20,6 +20,7 @@ pub mod operator;
 pub mod properties;
 pub mod rule;
 pub mod scalar;
+pub mod statistics;
 mod types;
 
 pub use column::*;

--- a/optd/core/src/ir/statistics.rs
+++ b/optd/core/src/ir/statistics.rs
@@ -1,0 +1,69 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Table statistics (row count + column stats)
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TableStatistics {
+    pub row_count: usize,
+    pub column_statistics: Vec<ColumnStatistics>,
+
+    /// File size in bytes
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size_bytes: Option<usize>,
+}
+
+/// Column statistics (external tables use column_id=0, name for identification)
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ColumnStatistics {
+    pub column_id: i64,
+    pub column_type: String,
+    pub name: String,
+    pub advanced_stats: Vec<AdvanceColumnStatistics>,
+
+    /// TODO(Aditya): Move this to Value?
+    /// Minimum value in the column (serialized as JSON string)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_value: Option<String>,
+    /// Maximum value in the column (serialized as JSON string)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_value: Option<String>,
+    /// Total number of null values
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub null_count: Option<usize>,
+    /// Number of distinct values (NDV)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub distinct_count: Option<usize>,
+}
+
+impl ColumnStatistics {
+    pub fn new(
+        column_id: i64,
+        column_type: String,
+        name: String,
+        advanced_stats: Vec<AdvanceColumnStatistics>,
+    ) -> Self {
+        Self {
+            column_id,
+            column_type,
+            name,
+            advanced_stats,
+            min_value: None,
+            max_value: None,
+            null_count: None,
+            distinct_count: None,
+        }
+    }
+
+    pub fn add_advanced_stat(&mut self, stat: AdvanceColumnStatistics) {
+        self.advanced_stats.push(stat);
+    }
+}
+
+/// An advanced statistics entry with type and serialized data at a snapshot.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AdvanceColumnStatistics {
+    /// Type of the statistical summaries (e.g., histogram, distinct count).
+    pub stats_type: String,
+    /// Serialized data for the statistics at a snapshot.
+    pub data: Value,
+}

--- a/optd/core/src/magic/card.rs
+++ b/optd/core/src/magic/card.rs
@@ -56,14 +56,12 @@ impl CardinalityEstimator for MagicCardinalityEstimator {
                 // Relies on the normalized expression's cardinality estimation.
                 panic!("right now should always be set");
             }
-            OperatorKind::LogicalGet(meta) => {
-                match ctx.cat.describe_table(meta.source).stats {
-                    Some(stats) => Cardinality::with_count_lossy(stats.row_count),
-                    None => Cardinality::with_count_lossy(
-                        MagicCardinalityEstimator::MAGIC_DEFAULT_CARDINALITY,
-                    ),
-                }
-            }
+            OperatorKind::LogicalGet(meta) => match ctx.cat.describe_table(meta.source).stats {
+                Some(stats) => Cardinality::with_count_lossy(stats.row_count),
+                None => Cardinality::with_count_lossy(
+                    MagicCardinalityEstimator::MAGIC_DEFAULT_CARDINALITY,
+                ),
+            },
             OperatorKind::PhysicalTableScan(meta) => {
                 match ctx.cat.describe_table(meta.source).stats {
                     Some(stats) => Cardinality::with_count_lossy(stats.row_count),

--- a/optd/core/src/magic/card.rs
+++ b/optd/core/src/magic/card.rs
@@ -12,6 +12,8 @@ impl MagicCardinalityEstimator {
     const MAGIC_JOIN_COND_SELECTIVITY: f64 = 0.4;
     const MAGIC_PREDICATE_SELECTIVITY: f64 = 0.1;
     const MAGIC_GROUP_BY_KEY_NDV_FACTOR: f64 = 0.2;
+
+    const MAGIC_DEFAULT_CARDINALITY: usize = 1000;
 }
 
 impl CardinalityEstimator for MagicCardinalityEstimator {
@@ -55,12 +57,20 @@ impl CardinalityEstimator for MagicCardinalityEstimator {
                 panic!("right now should always be set");
             }
             OperatorKind::LogicalGet(meta) => {
-                let exact_row_count = ctx.cat.describe_table(meta.source).row_count;
-                Cardinality::with_count_lossy(exact_row_count)
+                match ctx.cat.describe_table(meta.source).stats {
+                    Some(stats) => Cardinality::with_count_lossy(stats.row_count),
+                    None => Cardinality::with_count_lossy(
+                        MagicCardinalityEstimator::MAGIC_DEFAULT_CARDINALITY,
+                    ),
+                }
             }
             OperatorKind::PhysicalTableScan(meta) => {
-                let exact_row_count = ctx.cat.describe_table(meta.source).row_count;
-                Cardinality::with_count_lossy(exact_row_count)
+                match ctx.cat.describe_table(meta.source).stats {
+                    Some(stats) => Cardinality::with_count_lossy(stats.row_count),
+                    None => Cardinality::with_count_lossy(
+                        MagicCardinalityEstimator::MAGIC_DEFAULT_CARDINALITY,
+                    ),
+                }
             }
             OperatorKind::LogicalJoin(meta) => {
                 let join = LogicalJoin::borrow_raw_parts(meta, &op.common);

--- a/optd/core/src/magic/cat.rs
+++ b/optd/core/src/magic/cat.rs
@@ -6,7 +6,7 @@ use std::{
 use anyhow::bail;
 use tracing::info;
 
-use crate::ir::catalog::*;
+use crate::ir::{catalog::*, statistics::TableStatistics};
 
 pub struct MagicCatalog(RwLock<MagicCatalogInner>);
 
@@ -50,7 +50,32 @@ impl Catalog for MagicCatalog {
                 id,
                 name: table_name,
                 schema,
-                row_count: 0,
+                stats: None,
+            },
+        );
+        writer.next_table_id += 1;
+        Ok(id)
+    }
+
+    fn try_create_table_with_stats(
+        &self,
+        table_name: String,
+        schema: SchemaRef,
+        stats: TableStatistics,
+    ) -> Result<DataSourceId, DataSourceId> {
+        let mut writer = self.0.write().unwrap();
+        let id = DataSourceId(writer.next_table_id);
+        match writer.name_to_id.entry(table_name.clone()) {
+            Entry::Occupied(occupied) => return Err(*occupied.get()),
+            Entry::Vacant(vacant) => vacant.insert(id),
+        };
+        writer.tables.insert(
+            id,
+            TableMetadata {
+                id,
+                name: table_name,
+                schema,
+                stats: Some(stats),
             },
         );
         writer.next_table_id += 1;
@@ -71,10 +96,10 @@ impl Catalog for MagicCatalog {
         Ok(reader.tables.get(table_id).cloned().unwrap())
     }
 
-    fn set_table_row_count(&self, table_id: DataSourceId, row_count: usize) {
+    fn set_table_stats(&self, table_id: DataSourceId, stats: TableStatistics) {
         let mut writer = self.0.write().unwrap();
         let table = writer.tables.get_mut(&table_id).unwrap();
-        table.row_count = row_count;
+        table.stats = Some(stats);
     }
 }
 

--- a/optd/core/src/magic/mod.rs
+++ b/optd/core/src/magic/mod.rs
@@ -10,7 +10,11 @@ mod cm;
 
 use std::sync::Arc;
 
-use crate::ir::{DataType, catalog::*};
+use crate::ir::{
+    DataType,
+    catalog::*,
+    statistics::{ColumnStatistics, TableStatistics},
+};
 pub use card::MagicCardinalityEstimator;
 pub use cat::MagicCatalog;
 pub use cm::MagicCostModel;
@@ -34,10 +38,12 @@ impl IRContext {
             Arc::new(MagicCostModel),
         )
     }
+
     pub fn with_course_tables() -> Self {
         let catalog = MagicCatalog::default();
         let course = {
             let schema = Arc::new(Schema::new(vec![
+                // TODO: these .to_strings are not required?
                 Field::new("course.id".to_string(), DataType::Int32, false),
                 Field::new("course.credit".to_string(), DataType::Int32, false),
             ]));
@@ -46,7 +52,37 @@ impl IRContext {
                 .try_create_table("course".to_string(), schema)
                 .unwrap()
         };
-        catalog.set_table_row_count(course, 10);
+
+        // catalog.set_table_row_count(course, 10);
+        catalog.set_table_stats(
+            course,
+            TableStatistics {
+                row_count: 10,
+                column_statistics: vec![
+                    ColumnStatistics {
+                        column_id: 0,
+                        column_type: DataType::Int32.to_string(),
+                        name: "course.id".to_string(),
+                        advanced_stats: vec![],
+                        min_value: Some("0".to_string()),
+                        max_value: Some("9".to_string()),
+                        null_count: Some(0),
+                        distinct_count: Some(10),
+                    },
+                    ColumnStatistics {
+                        column_id: 0,
+                        column_type: DataType::Int32.to_string(),
+                        name: "course.credit".to_string(),
+                        advanced_stats: vec![],
+                        min_value: Some("3".to_string()),
+                        max_value: Some("15".to_string()),
+                        null_count: Some(0),
+                        distinct_count: Some(5),
+                    },
+                ],
+                size_bytes: Some((4 + 4) * 10),
+            },
+        );
 
         let schedule = {
             let schema = Arc::new(Schema::new(vec![
@@ -59,7 +95,47 @@ impl IRContext {
                 .try_create_table("schedule".to_string(), schema)
                 .unwrap()
         };
-        catalog.set_table_row_count(schedule, 25);
+
+        // catalog.set_table_row_count(schedule, 25);
+        catalog.set_table_stats(
+            schedule,
+            TableStatistics {
+                row_count: 25,
+                column_statistics: vec![
+                    ColumnStatistics {
+                        column_id: 0,
+                        column_type: DataType::Int32.to_string(),
+                        name: "schedule.day_of_week".to_string(),
+                        advanced_stats: vec![],
+                        min_value: Some("0".to_string()),
+                        max_value: Some("6".to_string()),
+                        null_count: Some(0),
+                        distinct_count: Some(7),
+                    },
+                    ColumnStatistics {
+                        column_id: 0,
+                        column_type: DataType::Int32.to_string(),
+                        name: "schedule.course_id".to_string(),
+                        advanced_stats: vec![],
+                        min_value: Some("0".to_string()),
+                        max_value: Some("9".to_string()),
+                        null_count: Some(0),
+                        distinct_count: Some(10),
+                    },
+                    ColumnStatistics {
+                        column_id: 0,
+                        column_type: DataType::Boolean.to_string(),
+                        name: "schedule.has_lecture".to_string(),
+                        advanced_stats: vec![],
+                        min_value: Some("0".to_string()),
+                        max_value: Some("1".to_string()),
+                        null_count: Some(0),
+                        distinct_count: Some(2),
+                    },
+                ],
+                size_bytes: Some((4 + 4 + 1) * 10),
+            },
+        );
 
         let staff = {
             let schema = Arc::new(Schema::new(vec![
@@ -73,26 +149,79 @@ impl IRContext {
                 .try_create_table("staff".to_string(), schema)
                 .unwrap()
         };
-        catalog.set_table_row_count(staff, 200);
+
+        // catalog.set_table_row_count(staff, 200);
+        catalog.set_table_stats(
+            staff,
+            TableStatistics {
+                row_count: 200,
+                column_statistics: vec![
+                    ColumnStatistics {
+                        column_id: 0,
+                        column_type: DataType::Int32.to_string(),
+                        name: "staff.id".to_string(),
+                        advanced_stats: vec![],
+                        min_value: Some("0".to_string()),
+                        max_value: Some("199".to_string()),
+                        null_count: Some(0),
+                        distinct_count: Some(200),
+                    },
+                    ColumnStatistics {
+                        column_id: 0,
+                        column_type: DataType::Int32.to_string(),
+                        name: "staff.oh_day_of_week".to_string(),
+                        advanced_stats: vec![],
+                        min_value: Some("0".to_string()),
+                        max_value: Some("6".to_string()),
+                        null_count: Some(0),
+                        distinct_count: Some(7),
+                    },
+                    ColumnStatistics {
+                        column_id: 0,
+                        column_type: DataType::Int32.to_string(),
+                        name: "staff.course_id".to_string(),
+                        advanced_stats: vec![],
+                        min_value: Some("0".to_string()),
+                        max_value: Some("9".to_string()),
+                        null_count: Some(0),
+                        distinct_count: Some(10),
+                    },
+                    ColumnStatistics {
+                        column_id: 0,
+                        column_type: DataType::Int32.to_string(),
+                        name: "staff.oh_length".to_string(),
+                        advanced_stats: vec![],
+                        min_value: Some("0".to_string()),
+                        max_value: Some("2".to_string()),
+                        null_count: Some(0),
+                        distinct_count: Some(3),
+                    },
+                ],
+                size_bytes: Some((4 + 4 + 4 + 4) * 10),
+            },
+        );
+
         Self::with_magic_catalog(catalog)
     }
+
     /// Creates a context with table `t1` to `t{count}`, each has `width` number of columns.
-    pub fn with_numbered_tables(row_counts: Vec<usize>, width: usize) -> Self {
+    pub fn with_numbered_tables(tables_statistics: Vec<TableStatistics>, width: usize) -> Self {
         let catalog = MagicCatalog::default();
 
-        let create_numbered_table = |table_name: String, width: usize, row_count: usize| {
-            let fields = (1..=width)
-                .map(|column_no| {
-                    Field::new(format!("{table_name}.v{column_no}"), DataType::Int32, false)
-                })
-                .collect_vec();
-            let schema = Arc::new(Schema::new(fields));
-            let table_id = catalog.try_create_table(table_name, schema).unwrap();
-            catalog.set_table_row_count(table_id, row_count);
-        };
+        let create_numbered_table =
+            |table_name: String, width: usize, table_statistics: TableStatistics| {
+                let fields = (1..=width)
+                    .map(|column_no| {
+                        Field::new(format!("{table_name}.v{column_no}"), DataType::Int32, false)
+                    })
+                    .collect_vec();
+                let schema = Arc::new(Schema::new(fields));
+                let table_id = catalog.try_create_table(table_name, schema).unwrap();
+                catalog.set_table_stats(table_id, table_statistics);
+            };
 
-        for (i, row_count) in row_counts.iter().enumerate() {
-            create_numbered_table(format!("t{i}"), width, *row_count);
+        for (i, table_statistics) in tables_statistics.into_iter().enumerate() {
+            create_numbered_table(format!("t{i}"), width, table_statistics);
         }
 
         Self::with_magic_catalog(catalog)


### PR DESCRIPTION
## Problem
Statistics types (`TableStatistics`, `ColumnStatistics`) were defined in the catalog crate 
but needed to be shared with optd-core. The Catalog trait only supported setting 
row counts, not full table statistics with column-level metadata. DataFusion 
connector wasn't extracting column statistics from execution stats.

## Summary of changes
- Moves `TableStatistics`, `ColumnStatistics`, and `AdvanceColumnStatistics` to 
  `optd-core/src/ir/statistics.rs` for broader reuse
- Refactors Catalog trait: adds `try_create_table_with_stats()`, changes 
  `set_table_row_count()` to `set_table_stats()`
- Updates DataFusion connector to extract column stats (min/max, null count, 
  distinct count) from DataFusion's `Precision` types  
- Updates `MagicCatalog`, `MagicCardinalityEstimator`, and test data to use new API
- Adds serde dependencies to `optd-core` and `catalog` crates