### PR TITLE
support predicate-pushdown through LeftSemi and LeftAnti joins

### DIFF
--- a/optd/core/src/rules/simplification/rewrite/select.rs
+++ b/optd/core/src/rules/simplification/rewrite/select.rs
@@ -120,7 +120,11 @@ impl RulePass for PushSelectThroughJoinRulePass {
                     }
                     JoinType::Single | JoinType::Mark(_) => top_filters.push(cond),
                     JoinType::LeftSemi | JoinType::LeftAnti => {
-                        top_filters.push(cond);
+                        if used.is_subset(outer_cols.as_ref()) {
+                            outer_filters.push(cond);
+                        } else {
+                            top_filters.push(cond);
+                        }
                     }
                 }
             }

--- a/optd/core/src/rules/simplification/tests.rs
+++ b/optd/core/src/rules/simplification/tests.rs
@@ -55,6 +55,43 @@ fn pushes_predicates_to_join_inputs_and_merges_selects() {
     );
 }
 
+fn assert_pushes_filter_to_outer_for_semi_or_anti(join_type: JoinType) {
+    let ctx = test_ctx_with_tables(&[("t1", 2), ("t2", 2)]).unwrap();
+    let left = ctx.logical_get(TableRef::bare("t1"), None).unwrap().build();
+    let right = ctx.logical_get(TableRef::bare("t2"), None).unwrap().build();
+    let t1_c0 = ctx.col(Some(&TableRef::bare("t1")), "c0").unwrap();
+
+    let plan = left
+        .with_ctx(&ctx)
+        .logical_join(right, boolean(true), join_type)
+        .select(column_ref(t1_c0).eq(int32(10)))
+        .build();
+
+    let simplified = SimplificationPass::new().apply(plan, &ctx).unwrap();
+    let join = simplified.try_borrow::<Join>().unwrap();
+    assert_eq!(join.join_type(), &join_type);
+    assert!(join.join_cond().is_true_scalar());
+    assert!(join.inner().try_borrow::<Select>().is_err());
+
+    let outer_filter = join.outer().try_borrow::<Select>().unwrap();
+    assert!(
+        outer_filter
+            .predicate()
+            .used_columns()
+            .is_subset(outer_filter.input().output_columns(&ctx).unwrap().as_ref())
+    );
+}
+
+#[test]
+fn pushes_predicates_to_outer_input_for_left_semi_join() {
+    assert_pushes_filter_to_outer_for_semi_or_anti(JoinType::LeftSemi);
+}
+
+#[test]
+fn pushes_predicates_to_outer_input_for_left_anti_join() {
+    assert_pushes_filter_to_outer_for_semi_or_anti(JoinType::LeftAnti);
+}
+
 // Input plan tree:
 // LogicalSelect [out > 5]
 //   LogicalProject [out := alias_left + 1, alias_right]

--- a/tests/sqlplannertest/tests/tpch/q16.planner.sql
+++ b/tests/sqlplannertest/tests/tpch/q16.planner.sql
@@ -131,7 +131,11 @@ OrderBy { ordering_exprs: [ "__#11.supplier_cnt"(#11.3) DESC, "__#11.p_brand"(#1
 
 physical_plan after optd-finalized:
 EnforcerSort { tuple_ordering: [(#11.3, Desc), (#11.0, Asc), (#11.1, Asc), (#11.2, Asc)], (.output_columns): [ "__#11.p_brand"(#11.0), "__#11.p_size"(#11.2), "__#11.p_type"(#11.1), "__#11.supplier_cnt"(#11.3) ], (.cardinality): 0.00 }
-└── Project { .table_index: 11, .projections: [ "part.p_brand"(#2.3), "part.p_type"(#2.4), "part.p_size"(#2.5), "__#9.count(alias1)"(#9.0) ], (.output_columns): [ "__#11.p_brand"(#11.0), "__#11.p_size"(#11.2), "__#11.p_type"(#11.1), "__#11.supplier_cnt"(#11.3) ], (.cardinality): 0.00 }
+└── Project
+    ├── .table_index: 11
+    ├── .projections: [ "part.p_brand"(#2.3), "part.p_type"(#2.4), "part.p_size"(#2.5), "__#9.count(alias1)"(#9.0) ]
+    ├── (.output_columns): [ "__#11.p_brand"(#11.0), "__#11.p_size"(#11.2), "__#11.p_type"(#11.1), "__#11.supplier_cnt"(#11.3) ]
+    ├── (.cardinality): 0.00
     └── Aggregate
         ├── .key_table_index: 8
         ├── .aggregate_table_index: 9
@@ -148,22 +152,27 @@ EnforcerSort { tuple_ordering: [(#11.3, Desc), (#11.0, Asc), (#11.1, Asc), (#11.
             ├── .keys: [ "part.p_brand"(#2.3), "part.p_type"(#2.4), "part.p_size"(#2.5), "partsupp.ps_suppkey"(#1.1) ]
             ├── (.output_columns): [ "__#6.alias1"(#6.3), "__#6.p_brand"(#6.0), "__#6.p_size"(#6.2), "__#6.p_type"(#6.1) ]
             ├── (.cardinality): 0.00
-            └── Select
-                ├── .predicate: ("partsupp.ps_partkey"(#1.0) = "part.p_partkey"(#2.0)) AND ("part.p_brand"(#2.3) != 'Brand#45'::utf8_view) AND ("part.p_type"(#2.4) NOT LIKE 'MEDIUM POLISHED%'::utf8_view) AND ("part.p_size"(#2.5) IN [49::integer, 14::integer, 23::integer, 45::integer, 19::integer, 3::integer, 36::integer, 9::integer])
+            └── Join
+                ├── .join_type: LeftAnti
+                ├── .implementation: None
+                ├── .join_cond: "partsupp.ps_suppkey"(#1.1) = "__correlated_sq_1.s_suppkey"(#5.0)
                 ├── (.output_columns): [ "part.p_brand"(#2.3), "part.p_partkey"(#2.0), "part.p_size"(#2.5), "part.p_type"(#2.4), "partsupp.ps_partkey"(#1.0), "partsupp.ps_suppkey"(#1.1) ]
                 ├── (.cardinality): 0.00
-                └── Join
-                    ├── .join_type: LeftAnti
-                    ├── .implementation: None
-                    ├── .join_cond: "partsupp.ps_suppkey"(#1.1) = "__correlated_sq_1.s_suppkey"(#5.0)
-                    ├── (.output_columns): [ "part.p_brand"(#2.3), "part.p_partkey"(#2.0), "part.p_size"(#2.5), "part.p_type"(#2.4), "partsupp.ps_partkey"(#1.0), "partsupp.ps_suppkey"(#1.1) ]
-                    ├── (.cardinality): 0.00
-                    ├── Join { .join_type: Inner, .implementation: None, .join_cond: true::boolean, (.output_columns): [ "part.p_brand"(#2.3), "part.p_partkey"(#2.0), "part.p_size"(#2.5), "part.p_type"(#2.4), "partsupp.ps_partkey"(#1.0), "partsupp.ps_suppkey"(#1.1) ], (.cardinality): 0.00 }
-                    │   ├── Get { .data_source_id: 5, .table_index: 1, .implementation: None, (.output_columns): [ "partsupp.ps_partkey"(#1.0), "partsupp.ps_suppkey"(#1.1) ], (.cardinality): 0.00 }
-                    │   └── Get { .data_source_id: 3, .table_index: 2, .implementation: None, (.output_columns): [ "part.p_brand"(#2.3), "part.p_partkey"(#2.0), "part.p_size"(#2.5), "part.p_type"(#2.4) ], (.cardinality): 0.00 }
-                    └── Remap { .table_index: 5, (.output_columns): "__correlated_sq_1.s_suppkey"(#5.0), (.cardinality): 0.00 }
-                        └── Project { .table_index: 4, .projections: "supplier.s_suppkey"(#3.0), (.output_columns): "__#4.s_suppkey"(#4.0), (.cardinality): 0.00 }
-                            └── Select { .predicate: "supplier.s_comment"(#3.6) LIKE '%Customer%Complaints%'::utf8_view, (.output_columns): [ "supplier.s_comment"(#3.6), "supplier.s_suppkey"(#3.0) ], (.cardinality): 0.00 }
-                                └── Get { .data_source_id: 4, .table_index: 3, .implementation: None, (.output_columns): [ "supplier.s_comment"(#3.6), "supplier.s_suppkey"(#3.0) ], (.cardinality): 0.00 }
+                ├── Join
+                │   ├── .join_type: Inner
+                │   ├── .implementation: None
+                │   ├── .join_cond: "partsupp.ps_partkey"(#1.0) = "part.p_partkey"(#2.0)
+                │   ├── (.output_columns): [ "part.p_brand"(#2.3), "part.p_partkey"(#2.0), "part.p_size"(#2.5), "part.p_type"(#2.4), "partsupp.ps_partkey"(#1.0), "partsupp.ps_suppkey"(#1.1) ]
+                │   ├── (.cardinality): 0.00
+                │   ├── Get { .data_source_id: 5, .table_index: 1, .implementation: None, (.output_columns): [ "partsupp.ps_partkey"(#1.0), "partsupp.ps_suppkey"(#1.1) ], (.cardinality): 0.00 }
+                │   └── Select
+                │       ├── .predicate: ("part.p_brand"(#2.3) != 'Brand#45'::utf8_view) AND ("part.p_type"(#2.4) NOT LIKE 'MEDIUM POLISHED%'::utf8_view) AND ("part.p_size"(#2.5) IN [49::integer, 14::integer, 23::integer, 45::integer, 19::integer, 3::integer, 36::integer, 9::integer])
+                │       ├── (.output_columns): [ "part.p_brand"(#2.3), "part.p_partkey"(#2.0), "part.p_size"(#2.5), "part.p_type"(#2.4) ]
+                │       ├── (.cardinality): 0.00
+                │       └── Get { .data_source_id: 3, .table_index: 2, .implementation: None, (.output_columns): [ "part.p_brand"(#2.3), "part.p_partkey"(#2.0), "part.p_size"(#2.5), "part.p_type"(#2.4) ], (.cardinality): 0.00 }
+                └── Remap { .table_index: 5, (.output_columns): "__correlated_sq_1.s_suppkey"(#5.0), (.cardinality): 0.00 }
+                    └── Project { .table_index: 4, .projections: "supplier.s_suppkey"(#3.0), (.output_columns): "__#4.s_suppkey"(#4.0), (.cardinality): 0.00 }
+                        └── Select { .predicate: "supplier.s_comment"(#3.6) LIKE '%Customer%Complaints%'::utf8_view, (.output_columns): [ "supplier.s_comment"(#3.6), "supplier.s_suppkey"(#3.0) ], (.cardinality): 0.00 }
+                            └── Get { .data_source_id: 4, .table_index: 3, .implementation: None, (.output_columns): [ "supplier.s_comment"(#3.6), "supplier.s_suppkey"(#3.0) ], (.cardinality): 0.00 }
 */
 

--- a/tests/sqlplannertest/tests/tpch/q18.planner.sql
+++ b/tests/sqlplannertest/tests/tpch/q18.planner.sql
@@ -380,8 +380,10 @@ Limit
             │   ├── "__#9.o_orderkey"(#9.2)
             │   └── "__#9.o_totalprice"(#9.4)
             ├── (.cardinality): 0.00
-            └── Select
-                ├── .predicate: ("orders.o_custkey"(#2.1) = "customer.c_custkey"(#1.0)) AND ("orders.o_orderkey"(#2.0) = "lineitem.l_orderkey"(#3.0))
+            └── Join
+                ├── .join_type: LeftSemi
+                ├── .implementation: None
+                ├── .join_cond: "orders.o_orderkey"(#2.0) = "__correlated_sq_1.l_orderkey"(#8.0)
                 ├── (.output_columns):
                 │   ┌── "customer.c_custkey"(#1.0)
                 │   ├── "customer.c_name"(#1.1)
@@ -392,91 +394,86 @@ Limit
                 │   ├── "orders.o_orderkey"(#2.0)
                 │   └── "orders.o_totalprice"(#2.3)
                 ├── (.cardinality): 0.00
-                └── Join
-                    ├── .join_type: LeftSemi
-                    ├── .implementation: None
-                    ├── .join_cond: "orders.o_orderkey"(#2.0) = "__correlated_sq_1.l_orderkey"(#8.0)
-                    ├── (.output_columns):
-                    │   ┌── "customer.c_custkey"(#1.0)
-                    │   ├── "customer.c_name"(#1.1)
-                    │   ├── "lineitem.l_orderkey"(#3.0)
-                    │   ├── "lineitem.l_quantity"(#3.4)
-                    │   ├── "orders.o_custkey"(#2.1)
-                    │   ├── "orders.o_orderdate"(#2.4)
-                    │   ├── "orders.o_orderkey"(#2.0)
-                    │   └── "orders.o_totalprice"(#2.3)
+                ├── Join
+                │   ├── .join_type: Inner
+                │   ├── .implementation: None
+                │   ├── .join_cond: "orders.o_orderkey"(#2.0) = "lineitem.l_orderkey"(#3.0)
+                │   ├── (.output_columns):
+                │   │   ┌── "customer.c_custkey"(#1.0)
+                │   │   ├── "customer.c_name"(#1.1)
+                │   │   ├── "lineitem.l_orderkey"(#3.0)
+                │   │   ├── "lineitem.l_quantity"(#3.4)
+                │   │   ├── "orders.o_custkey"(#2.1)
+                │   │   ├── "orders.o_orderdate"(#2.4)
+                │   │   ├── "orders.o_orderkey"(#2.0)
+                │   │   └── "orders.o_totalprice"(#2.3)
+                │   ├── (.cardinality): 0.00
+                │   ├── Join
+                │   │   ├── .join_type: Inner
+                │   │   ├── .implementation: None
+                │   │   ├── .join_cond: "orders.o_custkey"(#2.1) = "customer.c_custkey"(#1.0)
+                │   │   ├── (.output_columns):
+                │   │   │   ┌── "customer.c_custkey"(#1.0)
+                │   │   │   ├── "customer.c_name"(#1.1)
+                │   │   │   ├── "orders.o_custkey"(#2.1)
+                │   │   │   ├── "orders.o_orderdate"(#2.4)
+                │   │   │   ├── "orders.o_orderkey"(#2.0)
+                │   │   │   └── "orders.o_totalprice"(#2.3)
+                │   │   ├── (.cardinality): 0.00
+                │   │   ├── Get
+                │   │   │   ├── .data_source_id: 6
+                │   │   │   ├── .table_index: 1
+                │   │   │   ├── .implementation: None
+                │   │   │   ├── (.output_columns): [ "customer.c_custkey"(#1.0), "customer.c_name"(#1.1) ]
+                │   │   │   └── (.cardinality): 0.00
+                │   │   └── Get
+                │   │       ├── .data_source_id: 7
+                │   │       ├── .table_index: 2
+                │   │       ├── .implementation: None
+                │   │       ├── (.output_columns):
+                │   │       │   ┌── "orders.o_custkey"(#2.1)
+                │   │       │   ├── "orders.o_orderdate"(#2.4)
+                │   │       │   ├── "orders.o_orderkey"(#2.0)
+                │   │       │   └── "orders.o_totalprice"(#2.3)
+                │   │       └── (.cardinality): 0.00
+                │   └── Get
+                │       ├── .data_source_id: 8
+                │       ├── .table_index: 3
+                │       ├── .implementation: None
+                │       ├── (.output_columns): [ "lineitem.l_orderkey"(#3.0), "lineitem.l_quantity"(#3.4) ]
+                │       └── (.cardinality): 0.00
+                └── Remap
+                    ├── .table_index: 8
+                    ├── (.output_columns): "__correlated_sq_1.l_orderkey"(#8.0)
                     ├── (.cardinality): 0.00
-                    ├── Join
-                    │   ├── .join_type: Inner
-                    │   ├── .implementation: None
-                    │   ├── .join_cond: true::boolean
-                    │   ├── (.output_columns):
-                    │   │   ┌── "customer.c_custkey"(#1.0)
-                    │   │   ├── "customer.c_name"(#1.1)
-                    │   │   ├── "lineitem.l_orderkey"(#3.0)
-                    │   │   ├── "lineitem.l_quantity"(#3.4)
-                    │   │   ├── "orders.o_custkey"(#2.1)
-                    │   │   ├── "orders.o_orderdate"(#2.4)
-                    │   │   ├── "orders.o_orderkey"(#2.0)
-                    │   │   └── "orders.o_totalprice"(#2.3)
-                    │   ├── (.cardinality): 0.00
-                    │   ├── Join
-                    │   │   ├── .join_type: Inner
-                    │   │   ├── .implementation: None
-                    │   │   ├── .join_cond: true::boolean
-                    │   │   ├── (.output_columns):
-                    │   │   │   ┌── "customer.c_custkey"(#1.0)
-                    │   │   │   ├── "customer.c_name"(#1.1)
-                    │   │   │   ├── "orders.o_custkey"(#2.1)
-                    │   │   │   ├── "orders.o_orderdate"(#2.4)
-                    │   │   │   ├── "orders.o_orderkey"(#2.0)
-                    │   │   │   └── "orders.o_totalprice"(#2.3)
-                    │   │   ├── (.cardinality): 0.00
-                    │   │   ├── Get
-                    │   │   │   ├── .data_source_id: 6
-                    │   │   │   ├── .table_index: 1
-                    │   │   │   ├── .implementation: None
-                    │   │   │   ├── (.output_columns): [ "customer.c_custkey"(#1.0), "customer.c_name"(#1.1) ]
-                    │   │   │   └── (.cardinality): 0.00
-                    │   │   └── Get
-                    │   │       ├── .data_source_id: 7
-                    │   │       ├── .table_index: 2
-                    │   │       ├── .implementation: None
-                    │   │       ├── (.output_columns):
-                    │   │       │   ┌── "orders.o_custkey"(#2.1)
-                    │   │       │   ├── "orders.o_orderdate"(#2.4)
-                    │   │       │   ├── "orders.o_orderkey"(#2.0)
-                    │   │       │   └── "orders.o_totalprice"(#2.3)
-                    │   │       └── (.cardinality): 0.00
-                    │   └── Get
-                    │       ├── .data_source_id: 8
-                    │       ├── .table_index: 3
-                    │       ├── .implementation: None
-                    │       ├── (.output_columns): [ "lineitem.l_orderkey"(#3.0), "lineitem.l_quantity"(#3.4) ]
-                    │       └── (.cardinality): 0.00
-                    └── Remap { .table_index: 8, (.output_columns): "__correlated_sq_1.l_orderkey"(#8.0), (.cardinality): 0.00 }
-                        └── Project
-                            ├── .table_index: 7
-                            ├── .projections: "lineitem.l_orderkey"(#4.0)
-                            ├── (.output_columns): "__#7.l_orderkey"(#7.0)
+                    └── Project
+                        ├── .table_index: 7
+                        ├── .projections: "lineitem.l_orderkey"(#4.0)
+                        ├── (.output_columns): "__#7.l_orderkey"(#7.0)
+                        ├── (.cardinality): 0.00
+                        └── Select
+                            ├── .predicate: "__#6.sum(lineitem.l_quantity)"(#6.0) > 25000::decimal128(25, 2)
+                            ├── (.output_columns):
+                            │   ┌── "__#5.l_orderkey"(#5.0)
+                            │   └── "__#6.sum(lineitem.l_quantity)"(#6.0)
                             ├── (.cardinality): 0.00
-                            └── Select
-                                ├── .predicate: "__#6.sum(lineitem.l_quantity)"(#6.0) > 25000::decimal128(25, 2)
-                                ├── (.output_columns): [ "__#5.l_orderkey"(#5.0), "__#6.sum(lineitem.l_quantity)"(#6.0) ]
+                            └── Aggregate
+                                ├── .key_table_index: 5
+                                ├── .aggregate_table_index: 6
+                                ├── .implementation: None
+                                ├── .exprs: sum("lineitem.l_quantity"(#4.4))
+                                ├── .keys: "lineitem.l_orderkey"(#4.0)
+                                ├── (.output_columns):
+                                │   ┌── "__#5.l_orderkey"(#5.0)
+                                │   └── "__#6.sum(lineitem.l_quantity)"(#6.0)
                                 ├── (.cardinality): 0.00
-                                └── Aggregate
-                                    ├── .key_table_index: 5
-                                    ├── .aggregate_table_index: 6
+                                └── Get
+                                    ├── .data_source_id: 8
+                                    ├── .table_index: 4
                                     ├── .implementation: None
-                                    ├── .exprs: sum("lineitem.l_quantity"(#4.4))
-                                    ├── .keys: "lineitem.l_orderkey"(#4.0)
-                                    ├── (.output_columns): [ "__#5.l_orderkey"(#5.0), "__#6.sum(lineitem.l_quantity)"(#6.0) ]
-                                    ├── (.cardinality): 0.00
-                                    └── Get
-                                        ├── .data_source_id: 8
-                                        ├── .table_index: 4
-                                        ├── .implementation: None
-                                        ├── (.output_columns): [ "lineitem.l_orderkey"(#4.0), "lineitem.l_quantity"(#4.4) ]
-                                        └── (.cardinality): 0.00
+                                    ├── (.output_columns):
+                                    │   ┌── "lineitem.l_orderkey"(#4.0)
+                                    │   └── "lineitem.l_quantity"(#4.4)
+                                    └── (.cardinality): 0.00
 */
 

--- a/tests/sqlplannertest/tests/tpch/q20.planner.sql
+++ b/tests/sqlplannertest/tests/tpch/q20.planner.sql
@@ -312,68 +312,65 @@ OrderBy { ordering_exprs: "__#17.s_name"(#17.0) ASC, (.output_columns): [ "__#17
 physical_plan after optd-finalized:
 EnforcerSort { tuple_ordering: [(#17.0, Asc)], (.output_columns): [ "__#17.s_address"(#17.1), "__#17.s_name"(#17.0) ], (.cardinality): 0.00 }
 └── Project { .table_index: 17, .projections: [ "supplier.s_name"(#1.1), "supplier.s_address"(#1.2) ], (.output_columns): [ "__#17.s_address"(#17.1), "__#17.s_name"(#17.0) ], (.cardinality): 0.00 }
-    └── Select
-        ├── .predicate: ("supplier.s_nationkey"(#1.3) = "nation.n_nationkey"(#2.0)) AND ("nation.n_name"(#2.1) = 'IRAQ'::utf8_view)
+    └── Join
+        ├── .join_type: LeftSemi
+        ├── .implementation: None
+        ├── .join_cond: "supplier.s_suppkey"(#1.0) = "__correlated_sq_2.ps_suppkey"(#16.0)
         ├── (.output_columns): [ "nation.n_name"(#2.1), "nation.n_nationkey"(#2.0), "supplier.s_address"(#1.2), "supplier.s_name"(#1.1), "supplier.s_nationkey"(#1.3), "supplier.s_suppkey"(#1.0) ]
         ├── (.cardinality): 0.00
-        └── Join
-            ├── .join_type: LeftSemi
-            ├── .implementation: None
-            ├── .join_cond: "supplier.s_suppkey"(#1.0) = "__correlated_sq_2.ps_suppkey"(#16.0)
-            ├── (.output_columns): [ "nation.n_name"(#2.1), "nation.n_nationkey"(#2.0), "supplier.s_address"(#1.2), "supplier.s_name"(#1.1), "supplier.s_nationkey"(#1.3), "supplier.s_suppkey"(#1.0) ]
-            ├── (.cardinality): 0.00
-            ├── Join
-            │   ├── .join_type: Inner
-            │   ├── .implementation: None
-            │   ├── .join_cond: true::boolean
-            │   ├── (.output_columns): [ "nation.n_name"(#2.1), "nation.n_nationkey"(#2.0), "supplier.s_address"(#1.2), "supplier.s_name"(#1.1), "supplier.s_nationkey"(#1.3), "supplier.s_suppkey"(#1.0) ]
-            │   ├── (.cardinality): 0.00
-            │   ├── Get { .data_source_id: 4, .table_index: 1, .implementation: None, (.output_columns): [ "supplier.s_address"(#1.2), "supplier.s_name"(#1.1), "supplier.s_nationkey"(#1.3), "supplier.s_suppkey"(#1.0) ], (.cardinality): 0.00 }
-            │   └── Get { .data_source_id: 1, .table_index: 2, .implementation: None, (.output_columns): [ "nation.n_name"(#2.1), "nation.n_nationkey"(#2.0) ], (.cardinality): 0.00 }
-            └── Remap { .table_index: 16, (.output_columns): "__correlated_sq_2.ps_suppkey"(#16.0), (.cardinality): 0.00 }
-                └── Project { .table_index: 15, .projections: "partsupp.ps_suppkey"(#3.1), (.output_columns): "__#15.ps_suppkey"(#15.0), (.cardinality): 0.00 }
-                    └── Join
-                        ├── .join_type: Inner
-                        ├── .implementation: None
-                        ├── .join_cond: ("partsupp.ps_partkey"(#3.0) = "__scalar_sq_3.l_partkey"(#12.1)) AND ("partsupp.ps_suppkey"(#3.1) = "__scalar_sq_3.l_suppkey"(#12.2)) AND (CAST ("partsupp.ps_availqty"(#3.2) AS Float64) > "__scalar_sq_3.Float64(0.5) * sum(lineitem.l_quantity)"(#12.0))
-                        ├── (.output_columns):
-                        │   ┌── "__scalar_sq_3.Float64(0.5) * sum(lineitem.l_quantity)"(#12.0)
-                        │   ├── "__scalar_sq_3.__always_true"(#12.3)
-                        │   ├── "__scalar_sq_3.l_partkey"(#12.1)
-                        │   ├── "__scalar_sq_3.l_suppkey"(#12.2)
-                        │   ├── "partsupp.ps_availqty"(#3.2)
-                        │   ├── "partsupp.ps_partkey"(#3.0)
-                        │   └── "partsupp.ps_suppkey"(#3.1)
-                        ├── (.cardinality): 0.00
-                        ├── Join
-                        │   ├── .join_type: LeftSemi
-                        │   ├── .implementation: None
-                        │   ├── .join_cond: "partsupp.ps_partkey"(#3.0) = "__correlated_sq_1.p_partkey"(#6.0)
-                        │   ├── (.output_columns): [ "partsupp.ps_availqty"(#3.2), "partsupp.ps_partkey"(#3.0), "partsupp.ps_suppkey"(#3.1) ]
-                        │   ├── (.cardinality): 0.00
-                        │   ├── Get { .data_source_id: 5, .table_index: 3, .implementation: None, (.output_columns): [ "partsupp.ps_availqty"(#3.2), "partsupp.ps_partkey"(#3.0), "partsupp.ps_suppkey"(#3.1) ], (.cardinality): 0.00 }
-                        │   └── Remap { .table_index: 6, (.output_columns): "__correlated_sq_1.p_partkey"(#6.0), (.cardinality): 0.00 }
-                        │       └── Project { .table_index: 5, .projections: "part.p_partkey"(#4.0), (.output_columns): "__#5.p_partkey"(#5.0), (.cardinality): 0.00 }
-                        │           └── Select { .predicate: "part.p_name"(#4.1) LIKE 'indian%'::utf8_view, (.output_columns): [ "part.p_name"(#4.1), "part.p_partkey"(#4.0) ], (.cardinality): 0.00 }
-                        │               └── Get { .data_source_id: 3, .table_index: 4, .implementation: None, (.output_columns): [ "part.p_name"(#4.1), "part.p_partkey"(#4.0) ], (.cardinality): 0.00 }
-                        └── Remap { .table_index: 12, (.output_columns): [ "__scalar_sq_3.Float64(0.5) * sum(lineitem.l_quantity)"(#12.0), "__scalar_sq_3.__always_true"(#12.3), "__scalar_sq_3.l_partkey"(#12.1), "__scalar_sq_3.l_suppkey"(#12.2) ], (.cardinality): 0.00 }
-                            └── Project
-                                ├── .table_index: 11
-                                ├── .projections: [ 0.5::float64 * CAST ("__#9.sum(lineitem.l_quantity)"(#9.0) AS Float64), "lineitem.l_partkey"(#7.1), "lineitem.l_suppkey"(#7.2), true::boolean ]
-                                ├── (.output_columns): [ "__#11.Float64(0.5) * sum(lineitem.l_quantity)"(#11.0), "__#11.__always_true"(#11.3), "__#11.l_partkey"(#11.1), "__#11.l_suppkey"(#11.2) ]
+        ├── Join
+        │   ├── .join_type: Inner
+        │   ├── .implementation: None
+        │   ├── .join_cond: "supplier.s_nationkey"(#1.3) = "nation.n_nationkey"(#2.0)
+        │   ├── (.output_columns): [ "nation.n_name"(#2.1), "nation.n_nationkey"(#2.0), "supplier.s_address"(#1.2), "supplier.s_name"(#1.1), "supplier.s_nationkey"(#1.3), "supplier.s_suppkey"(#1.0) ]
+        │   ├── (.cardinality): 0.00
+        │   ├── Get { .data_source_id: 4, .table_index: 1, .implementation: None, (.output_columns): [ "supplier.s_address"(#1.2), "supplier.s_name"(#1.1), "supplier.s_nationkey"(#1.3), "supplier.s_suppkey"(#1.0) ], (.cardinality): 0.00 }
+        │   └── Select { .predicate: "nation.n_name"(#2.1) = 'IRAQ'::utf8_view, (.output_columns): [ "nation.n_name"(#2.1), "nation.n_nationkey"(#2.0) ], (.cardinality): 0.00 }
+        │       └── Get { .data_source_id: 1, .table_index: 2, .implementation: None, (.output_columns): [ "nation.n_name"(#2.1), "nation.n_nationkey"(#2.0) ], (.cardinality): 0.00 }
+        └── Remap { .table_index: 16, (.output_columns): "__correlated_sq_2.ps_suppkey"(#16.0), (.cardinality): 0.00 }
+            └── Project { .table_index: 15, .projections: "partsupp.ps_suppkey"(#3.1), (.output_columns): "__#15.ps_suppkey"(#15.0), (.cardinality): 0.00 }
+                └── Join
+                    ├── .join_type: Inner
+                    ├── .implementation: None
+                    ├── .join_cond: ("partsupp.ps_partkey"(#3.0) = "__scalar_sq_3.l_partkey"(#12.1)) AND ("partsupp.ps_suppkey"(#3.1) = "__scalar_sq_3.l_suppkey"(#12.2)) AND (CAST ("partsupp.ps_availqty"(#3.2) AS Float64) > "__scalar_sq_3.Float64(0.5) * sum(lineitem.l_quantity)"(#12.0))
+                    ├── (.output_columns):
+                    │   ┌── "__scalar_sq_3.Float64(0.5) * sum(lineitem.l_quantity)"(#12.0)
+                    │   ├── "__scalar_sq_3.__always_true"(#12.3)
+                    │   ├── "__scalar_sq_3.l_partkey"(#12.1)
+                    │   ├── "__scalar_sq_3.l_suppkey"(#12.2)
+                    │   ├── "partsupp.ps_availqty"(#3.2)
+                    │   ├── "partsupp.ps_partkey"(#3.0)
+                    │   └── "partsupp.ps_suppkey"(#3.1)
+                    ├── (.cardinality): 0.00
+                    ├── Join
+                    │   ├── .join_type: LeftSemi
+                    │   ├── .implementation: None
+                    │   ├── .join_cond: "partsupp.ps_partkey"(#3.0) = "__correlated_sq_1.p_partkey"(#6.0)
+                    │   ├── (.output_columns): [ "partsupp.ps_availqty"(#3.2), "partsupp.ps_partkey"(#3.0), "partsupp.ps_suppkey"(#3.1) ]
+                    │   ├── (.cardinality): 0.00
+                    │   ├── Get { .data_source_id: 5, .table_index: 3, .implementation: None, (.output_columns): [ "partsupp.ps_availqty"(#3.2), "partsupp.ps_partkey"(#3.0), "partsupp.ps_suppkey"(#3.1) ], (.cardinality): 0.00 }
+                    │   └── Remap { .table_index: 6, (.output_columns): "__correlated_sq_1.p_partkey"(#6.0), (.cardinality): 0.00 }
+                    │       └── Project { .table_index: 5, .projections: "part.p_partkey"(#4.0), (.output_columns): "__#5.p_partkey"(#5.0), (.cardinality): 0.00 }
+                    │           └── Select { .predicate: "part.p_name"(#4.1) LIKE 'indian%'::utf8_view, (.output_columns): [ "part.p_name"(#4.1), "part.p_partkey"(#4.0) ], (.cardinality): 0.00 }
+                    │               └── Get { .data_source_id: 3, .table_index: 4, .implementation: None, (.output_columns): [ "part.p_name"(#4.1), "part.p_partkey"(#4.0) ], (.cardinality): 0.00 }
+                    └── Remap { .table_index: 12, (.output_columns): [ "__scalar_sq_3.Float64(0.5) * sum(lineitem.l_quantity)"(#12.0), "__scalar_sq_3.__always_true"(#12.3), "__scalar_sq_3.l_partkey"(#12.1), "__scalar_sq_3.l_suppkey"(#12.2) ], (.cardinality): 0.00 }
+                        └── Project
+                            ├── .table_index: 11
+                            ├── .projections: [ 0.5::float64 * CAST ("__#9.sum(lineitem.l_quantity)"(#9.0) AS Float64), "lineitem.l_partkey"(#7.1), "lineitem.l_suppkey"(#7.2), true::boolean ]
+                            ├── (.output_columns): [ "__#11.Float64(0.5) * sum(lineitem.l_quantity)"(#11.0), "__#11.__always_true"(#11.3), "__#11.l_partkey"(#11.1), "__#11.l_suppkey"(#11.2) ]
+                            ├── (.cardinality): 0.00
+                            └── Aggregate
+                                ├── .key_table_index: 8
+                                ├── .aggregate_table_index: 9
+                                ├── .implementation: None
+                                ├── .exprs: sum("lineitem.l_quantity"(#7.4))
+                                ├── .keys: [ "lineitem.l_partkey"(#7.1), "lineitem.l_suppkey"(#7.2) ]
+                                ├── (.output_columns): [ "__#8.l_partkey"(#8.0), "__#8.l_suppkey"(#8.1), "__#9.sum(lineitem.l_quantity)"(#9.0) ]
                                 ├── (.cardinality): 0.00
-                                └── Aggregate
-                                    ├── .key_table_index: 8
-                                    ├── .aggregate_table_index: 9
-                                    ├── .implementation: None
-                                    ├── .exprs: sum("lineitem.l_quantity"(#7.4))
-                                    ├── .keys: [ "lineitem.l_partkey"(#7.1), "lineitem.l_suppkey"(#7.2) ]
-                                    ├── (.output_columns): [ "__#8.l_partkey"(#8.0), "__#8.l_suppkey"(#8.1), "__#9.sum(lineitem.l_quantity)"(#9.0) ]
+                                └── Select
+                                    ├── .predicate: ("lineitem.l_shipdate"(#7.10) >= 1996-01-01::date32) AND ("lineitem.l_shipdate"(#7.10) < 1997-01-01::date32)
+                                    ├── (.output_columns): [ "lineitem.l_partkey"(#7.1), "lineitem.l_quantity"(#7.4), "lineitem.l_shipdate"(#7.10), "lineitem.l_suppkey"(#7.2) ]
                                     ├── (.cardinality): 0.00
-                                    └── Select
-                                        ├── .predicate: ("lineitem.l_shipdate"(#7.10) >= 1996-01-01::date32) AND ("lineitem.l_shipdate"(#7.10) < 1997-01-01::date32)
-                                        ├── (.output_columns): [ "lineitem.l_partkey"(#7.1), "lineitem.l_quantity"(#7.4), "lineitem.l_shipdate"(#7.10), "lineitem.l_suppkey"(#7.2) ]
-                                        ├── (.cardinality): 0.00
-                                        └── Get { .data_source_id: 8, .table_index: 7, .implementation: None, (.output_columns): [ "lineitem.l_partkey"(#7.1), "lineitem.l_quantity"(#7.4), "lineitem.l_shipdate"(#7.10), "lineitem.l_suppkey"(#7.2) ], (.cardinality): 0.00 }
+                                    └── Get { .data_source_id: 8, .table_index: 7, .implementation: None, (.output_columns): [ "lineitem.l_partkey"(#7.1), "lineitem.l_quantity"(#7.4), "lineitem.l_shipdate"(#7.10), "lineitem.l_suppkey"(#7.2) ], (.cardinality): 0.00 }
 */
 

--- a/tests/sqlplannertest/tests/tpch/q21.planner.sql
+++ b/tests/sqlplannertest/tests/tpch/q21.planner.sql
@@ -551,10 +551,23 @@ Limit { .skip: 0::bigint, .fetch: 100::bigint, (.output_columns): [ "__#16.numwa
 physical_plan after optd-finalized:
 Limit { .skip: 0::bigint, .fetch: 100::bigint, (.output_columns): [ "__#16.numwait"(#16.1), "__#16.s_name"(#16.0) ], (.cardinality): 0.00 }
 └── EnforcerSort { tuple_ordering: [(#16.1, Desc), (#16.0, Asc)], (.output_columns): [ "__#16.numwait"(#16.1), "__#16.s_name"(#16.0) ], (.cardinality): 0.00 }
-    └── Project { .table_index: 16, .projections: [ "supplier.s_name"(#1.1), "__#15.count(Int64(1))"(#15.0) ], (.output_columns): [ "__#16.numwait"(#16.1), "__#16.s_name"(#16.0) ], (.cardinality): 0.00 }
-        └── Aggregate { .key_table_index: 14, .aggregate_table_index: 15, .implementation: None, .exprs: count(1::bigint), .keys: "supplier.s_name"(#1.1), (.output_columns): [ "__#14.s_name"(#14.0), "__#15.count(Int64(1))"(#15.0) ], (.cardinality): 0.00 }
-            └── Select
-                ├── .predicate: ("supplier.s_suppkey"(#1.0) = "l1.l_suppkey"(#3.2)) AND ("orders.o_orderkey"(#4.0) = "l1.l_orderkey"(#3.0)) AND ("orders.o_orderstatus"(#4.2) = 'F'::utf8_view) AND ("l1.l_receiptdate"(#3.12) > "l1.l_commitdate"(#3.11)) AND ("supplier.s_nationkey"(#1.3) = "nation.n_nationkey"(#5.0)) AND ("nation.n_name"(#5.1) = 'SAUDI ARABIA'::utf8_view)
+    └── Project
+        ├── .table_index: 16
+        ├── .projections: [ "supplier.s_name"(#1.1), "__#15.count(Int64(1))"(#15.0) ]
+        ├── (.output_columns): [ "__#16.numwait"(#16.1), "__#16.s_name"(#16.0) ]
+        ├── (.cardinality): 0.00
+        └── Aggregate
+            ├── .key_table_index: 14
+            ├── .aggregate_table_index: 15
+            ├── .implementation: None
+            ├── .exprs: count(1::bigint)
+            ├── .keys: "supplier.s_name"(#1.1)
+            ├── (.output_columns): [ "__#14.s_name"(#14.0), "__#15.count(Int64(1))"(#15.0) ]
+            ├── (.cardinality): 0.00
+            └── Join
+                ├── .join_type: LeftAnti
+                ├── .implementation: None
+                ├── .join_cond: ("l1.l_orderkey"(#3.0) = "__correlated_sq_2.l_orderkey"(#13.0)) AND ("__correlated_sq_2.l_suppkey"(#13.2) != "l1.l_suppkey"(#3.2))
                 ├── (.output_columns):
                 │   ┌── "l1.l_comment"(#3.15)
                 │   ├── "l1.l_commitdate"(#3.11)
@@ -580,348 +593,382 @@ Limit { .skip: 0::bigint, .fetch: 100::bigint, (.output_columns): [ "__#16.numwa
                 │   ├── "supplier.s_nationkey"(#1.3)
                 │   └── "supplier.s_suppkey"(#1.0)
                 ├── (.cardinality): 0.00
-                └── Join
-                    ├── .join_type: LeftAnti
-                    ├── .implementation: None
-                    ├── .join_cond: ("l1.l_orderkey"(#3.0) = "__correlated_sq_2.l_orderkey"(#13.0)) AND ("__correlated_sq_2.l_suppkey"(#13.2) != "l1.l_suppkey"(#3.2))
+                ├── Join
+                │   ├── .join_type: LeftSemi
+                │   ├── .implementation: None
+                │   ├── .join_cond: ("l1.l_orderkey"(#3.0) = "__correlated_sq_1.l_orderkey"(#9.0)) AND ("__correlated_sq_1.l_suppkey"(#9.2) != "l1.l_suppkey"(#3.2))
+                │   ├── (.output_columns):
+                │   │   ┌── "l1.l_comment"(#3.15)
+                │   │   ├── "l1.l_commitdate"(#3.11)
+                │   │   ├── "l1.l_discount"(#3.6)
+                │   │   ├── "l1.l_extendedprice"(#3.5)
+                │   │   ├── "l1.l_linenumber"(#3.3)
+                │   │   ├── "l1.l_linestatus"(#3.9)
+                │   │   ├── "l1.l_orderkey"(#3.0)
+                │   │   ├── "l1.l_partkey"(#3.1)
+                │   │   ├── "l1.l_quantity"(#3.4)
+                │   │   ├── "l1.l_receiptdate"(#3.12)
+                │   │   ├── "l1.l_returnflag"(#3.8)
+                │   │   ├── "l1.l_shipdate"(#3.10)
+                │   │   ├── "l1.l_shipinstruct"(#3.13)
+                │   │   ├── "l1.l_shipmode"(#3.14)
+                │   │   ├── "l1.l_suppkey"(#3.2)
+                │   │   ├── "l1.l_tax"(#3.7)
+                │   │   ├── "nation.n_name"(#5.1)
+                │   │   ├── "nation.n_nationkey"(#5.0)
+                │   │   ├── "orders.o_orderkey"(#4.0)
+                │   │   ├── "orders.o_orderstatus"(#4.2)
+                │   │   ├── "supplier.s_name"(#1.1)
+                │   │   ├── "supplier.s_nationkey"(#1.3)
+                │   │   └── "supplier.s_suppkey"(#1.0)
+                │   ├── (.cardinality): 0.00
+                │   ├── Join
+                │   │   ├── .join_type: Inner
+                │   │   ├── .implementation: None
+                │   │   ├── .join_cond: "supplier.s_nationkey"(#1.3) = "nation.n_nationkey"(#5.0)
+                │   │   ├── (.output_columns):
+                │   │   │   ┌── "l1.l_comment"(#3.15)
+                │   │   │   ├── "l1.l_commitdate"(#3.11)
+                │   │   │   ├── "l1.l_discount"(#3.6)
+                │   │   │   ├── "l1.l_extendedprice"(#3.5)
+                │   │   │   ├── "l1.l_linenumber"(#3.3)
+                │   │   │   ├── "l1.l_linestatus"(#3.9)
+                │   │   │   ├── "l1.l_orderkey"(#3.0)
+                │   │   │   ├── "l1.l_partkey"(#3.1)
+                │   │   │   ├── "l1.l_quantity"(#3.4)
+                │   │   │   ├── "l1.l_receiptdate"(#3.12)
+                │   │   │   ├── "l1.l_returnflag"(#3.8)
+                │   │   │   ├── "l1.l_shipdate"(#3.10)
+                │   │   │   ├── "l1.l_shipinstruct"(#3.13)
+                │   │   │   ├── "l1.l_shipmode"(#3.14)
+                │   │   │   ├── "l1.l_suppkey"(#3.2)
+                │   │   │   ├── "l1.l_tax"(#3.7)
+                │   │   │   ├── "nation.n_name"(#5.1)
+                │   │   │   ├── "nation.n_nationkey"(#5.0)
+                │   │   │   ├── "orders.o_orderkey"(#4.0)
+                │   │   │   ├── "orders.o_orderstatus"(#4.2)
+                │   │   │   ├── "supplier.s_name"(#1.1)
+                │   │   │   ├── "supplier.s_nationkey"(#1.3)
+                │   │   │   └── "supplier.s_suppkey"(#1.0)
+                │   │   ├── (.cardinality): 0.00
+                │   │   ├── Join
+                │   │   │   ├── .join_type: Inner
+                │   │   │   ├── .implementation: None
+                │   │   │   ├── .join_cond: "orders.o_orderkey"(#4.0) = "l1.l_orderkey"(#3.0)
+                │   │   │   ├── (.output_columns):
+                │   │   │   │   ┌── "l1.l_comment"(#3.15)
+                │   │   │   │   ├── "l1.l_commitdate"(#3.11)
+                │   │   │   │   ├── "l1.l_discount"(#3.6)
+                │   │   │   │   ├── "l1.l_extendedprice"(#3.5)
+                │   │   │   │   ├── "l1.l_linenumber"(#3.3)
+                │   │   │   │   ├── "l1.l_linestatus"(#3.9)
+                │   │   │   │   ├── "l1.l_orderkey"(#3.0)
+                │   │   │   │   ├── "l1.l_partkey"(#3.1)
+                │   │   │   │   ├── "l1.l_quantity"(#3.4)
+                │   │   │   │   ├── "l1.l_receiptdate"(#3.12)
+                │   │   │   │   ├── "l1.l_returnflag"(#3.8)
+                │   │   │   │   ├── "l1.l_shipdate"(#3.10)
+                │   │   │   │   ├── "l1.l_shipinstruct"(#3.13)
+                │   │   │   │   ├── "l1.l_shipmode"(#3.14)
+                │   │   │   │   ├── "l1.l_suppkey"(#3.2)
+                │   │   │   │   ├── "l1.l_tax"(#3.7)
+                │   │   │   │   ├── "orders.o_orderkey"(#4.0)
+                │   │   │   │   ├── "orders.o_orderstatus"(#4.2)
+                │   │   │   │   ├── "supplier.s_name"(#1.1)
+                │   │   │   │   ├── "supplier.s_nationkey"(#1.3)
+                │   │   │   │   └── "supplier.s_suppkey"(#1.0)
+                │   │   │   ├── (.cardinality): 0.00
+                │   │   │   ├── Join
+                │   │   │   │   ├── .join_type: Inner
+                │   │   │   │   ├── .implementation: None
+                │   │   │   │   ├── .join_cond: "supplier.s_suppkey"(#1.0) = "l1.l_suppkey"(#3.2)
+                │   │   │   │   ├── (.output_columns):
+                │   │   │   │   │   ┌── "l1.l_comment"(#3.15)
+                │   │   │   │   │   ├── "l1.l_commitdate"(#3.11)
+                │   │   │   │   │   ├── "l1.l_discount"(#3.6)
+                │   │   │   │   │   ├── "l1.l_extendedprice"(#3.5)
+                │   │   │   │   │   ├── "l1.l_linenumber"(#3.3)
+                │   │   │   │   │   ├── "l1.l_linestatus"(#3.9)
+                │   │   │   │   │   ├── "l1.l_orderkey"(#3.0)
+                │   │   │   │   │   ├── "l1.l_partkey"(#3.1)
+                │   │   │   │   │   ├── "l1.l_quantity"(#3.4)
+                │   │   │   │   │   ├── "l1.l_receiptdate"(#3.12)
+                │   │   │   │   │   ├── "l1.l_returnflag"(#3.8)
+                │   │   │   │   │   ├── "l1.l_shipdate"(#3.10)
+                │   │   │   │   │   ├── "l1.l_shipinstruct"(#3.13)
+                │   │   │   │   │   ├── "l1.l_shipmode"(#3.14)
+                │   │   │   │   │   ├── "l1.l_suppkey"(#3.2)
+                │   │   │   │   │   ├── "l1.l_tax"(#3.7)
+                │   │   │   │   │   ├── "supplier.s_name"(#1.1)
+                │   │   │   │   │   ├── "supplier.s_nationkey"(#1.3)
+                │   │   │   │   │   └── "supplier.s_suppkey"(#1.0)
+                │   │   │   │   ├── (.cardinality): 0.00
+                │   │   │   │   ├── Get
+                │   │   │   │   │   ├── .data_source_id: 4
+                │   │   │   │   │   ├── .table_index: 1
+                │   │   │   │   │   ├── .implementation: None
+                │   │   │   │   │   ├── (.output_columns): [ "supplier.s_name"(#1.1), "supplier.s_nationkey"(#1.3), "supplier.s_suppkey"(#1.0) ]
+                │   │   │   │   │   └── (.cardinality): 0.00
+                │   │   │   │   └── Select
+                │   │   │   │       ├── .predicate: "l1.l_receiptdate"(#3.12) > "l1.l_commitdate"(#3.11)
+                │   │   │   │       ├── (.output_columns):
+                │   │   │   │       │   ┌── "l1.l_comment"(#3.15)
+                │   │   │   │       │   ├── "l1.l_commitdate"(#3.11)
+                │   │   │   │       │   ├── "l1.l_discount"(#3.6)
+                │   │   │   │       │   ├── "l1.l_extendedprice"(#3.5)
+                │   │   │   │       │   ├── "l1.l_linenumber"(#3.3)
+                │   │   │   │       │   ├── "l1.l_linestatus"(#3.9)
+                │   │   │   │       │   ├── "l1.l_orderkey"(#3.0)
+                │   │   │   │       │   ├── "l1.l_partkey"(#3.1)
+                │   │   │   │       │   ├── "l1.l_quantity"(#3.4)
+                │   │   │   │       │   ├── "l1.l_receiptdate"(#3.12)
+                │   │   │   │       │   ├── "l1.l_returnflag"(#3.8)
+                │   │   │   │       │   ├── "l1.l_shipdate"(#3.10)
+                │   │   │   │       │   ├── "l1.l_shipinstruct"(#3.13)
+                │   │   │   │       │   ├── "l1.l_shipmode"(#3.14)
+                │   │   │   │       │   ├── "l1.l_suppkey"(#3.2)
+                │   │   │   │       │   └── "l1.l_tax"(#3.7)
+                │   │   │   │       ├── (.cardinality): 0.00
+                │   │   │   │       └── Remap
+                │   │   │   │           ├── .table_index: 3
+                │   │   │   │           ├── (.output_columns):
+                │   │   │   │           │   ┌── "l1.l_comment"(#3.15)
+                │   │   │   │           │   ├── "l1.l_commitdate"(#3.11)
+                │   │   │   │           │   ├── "l1.l_discount"(#3.6)
+                │   │   │   │           │   ├── "l1.l_extendedprice"(#3.5)
+                │   │   │   │           │   ├── "l1.l_linenumber"(#3.3)
+                │   │   │   │           │   ├── "l1.l_linestatus"(#3.9)
+                │   │   │   │           │   ├── "l1.l_orderkey"(#3.0)
+                │   │   │   │           │   ├── "l1.l_partkey"(#3.1)
+                │   │   │   │           │   ├── "l1.l_quantity"(#3.4)
+                │   │   │   │           │   ├── "l1.l_receiptdate"(#3.12)
+                │   │   │   │           │   ├── "l1.l_returnflag"(#3.8)
+                │   │   │   │           │   ├── "l1.l_shipdate"(#3.10)
+                │   │   │   │           │   ├── "l1.l_shipinstruct"(#3.13)
+                │   │   │   │           │   ├── "l1.l_shipmode"(#3.14)
+                │   │   │   │           │   ├── "l1.l_suppkey"(#3.2)
+                │   │   │   │           │   └── "l1.l_tax"(#3.7)
+                │   │   │   │           ├── (.cardinality): 0.00
+                │   │   │   │           └── Get
+                │   │   │   │               ├── .data_source_id: 8
+                │   │   │   │               ├── .table_index: 2
+                │   │   │   │               ├── .implementation: None
+                │   │   │   │               ├── (.output_columns):
+                │   │   │   │               │   ┌── "lineitem.l_comment"(#2.15)
+                │   │   │   │               │   ├── "lineitem.l_commitdate"(#2.11)
+                │   │   │   │               │   ├── "lineitem.l_discount"(#2.6)
+                │   │   │   │               │   ├── "lineitem.l_extendedprice"(#2.5)
+                │   │   │   │               │   ├── "lineitem.l_linenumber"(#2.3)
+                │   │   │   │               │   ├── "lineitem.l_linestatus"(#2.9)
+                │   │   │   │               │   ├── "lineitem.l_orderkey"(#2.0)
+                │   │   │   │               │   ├── "lineitem.l_partkey"(#2.1)
+                │   │   │   │               │   ├── "lineitem.l_quantity"(#2.4)
+                │   │   │   │               │   ├── "lineitem.l_receiptdate"(#2.12)
+                │   │   │   │               │   ├── "lineitem.l_returnflag"(#2.8)
+                │   │   │   │               │   ├── "lineitem.l_shipdate"(#2.10)
+                │   │   │   │               │   ├── "lineitem.l_shipinstruct"(#2.13)
+                │   │   │   │               │   ├── "lineitem.l_shipmode"(#2.14)
+                │   │   │   │               │   ├── "lineitem.l_suppkey"(#2.2)
+                │   │   │   │               │   └── "lineitem.l_tax"(#2.7)
+                │   │   │   │               └── (.cardinality): 0.00
+                │   │   │   └── Select
+                │   │   │       ├── .predicate: "orders.o_orderstatus"(#4.2) = 'F'::utf8_view
+                │   │   │       ├── (.output_columns): [ "orders.o_orderkey"(#4.0), "orders.o_orderstatus"(#4.2) ]
+                │   │   │       ├── (.cardinality): 0.00
+                │   │   │       └── Get
+                │   │   │           ├── .data_source_id: 7
+                │   │   │           ├── .table_index: 4
+                │   │   │           ├── .implementation: None
+                │   │   │           ├── (.output_columns): [ "orders.o_orderkey"(#4.0), "orders.o_orderstatus"(#4.2) ]
+                │   │   │           └── (.cardinality): 0.00
+                │   │   └── Select
+                │   │       ├── .predicate: "nation.n_name"(#5.1) = 'SAUDI ARABIA'::utf8_view
+                │   │       ├── (.output_columns): [ "nation.n_name"(#5.1), "nation.n_nationkey"(#5.0) ]
+                │   │       ├── (.cardinality): 0.00
+                │   │       └── Get
+                │   │           ├── .data_source_id: 1
+                │   │           ├── .table_index: 5
+                │   │           ├── .implementation: None
+                │   │           ├── (.output_columns): [ "nation.n_name"(#5.1), "nation.n_nationkey"(#5.0) ]
+                │   │           └── (.cardinality): 0.00
+                │   └── Remap
+                │       ├── .table_index: 9
+                │       ├── (.output_columns):
+                │       │   ┌── "__correlated_sq_1.l_comment"(#9.15)
+                │       │   ├── "__correlated_sq_1.l_commitdate"(#9.11)
+                │       │   ├── "__correlated_sq_1.l_discount"(#9.6)
+                │       │   ├── "__correlated_sq_1.l_extendedprice"(#9.5)
+                │       │   ├── "__correlated_sq_1.l_linenumber"(#9.3)
+                │       │   ├── "__correlated_sq_1.l_linestatus"(#9.9)
+                │       │   ├── "__correlated_sq_1.l_orderkey"(#9.0)
+                │       │   ├── "__correlated_sq_1.l_partkey"(#9.1)
+                │       │   ├── "__correlated_sq_1.l_quantity"(#9.4)
+                │       │   ├── "__correlated_sq_1.l_receiptdate"(#9.12)
+                │       │   ├── "__correlated_sq_1.l_returnflag"(#9.8)
+                │       │   ├── "__correlated_sq_1.l_shipdate"(#9.10)
+                │       │   ├── "__correlated_sq_1.l_shipinstruct"(#9.13)
+                │       │   ├── "__correlated_sq_1.l_shipmode"(#9.14)
+                │       │   ├── "__correlated_sq_1.l_suppkey"(#9.2)
+                │       │   └── "__correlated_sq_1.l_tax"(#9.7)
+                │       ├── (.cardinality): 0.00
+                │       └── Project
+                │           ├── .table_index: 8
+                │           ├── .projections:
+                │           │   ┌── "l2.l_orderkey"(#7.0)
+                │           │   ├── "l2.l_partkey"(#7.1)
+                │           │   ├── "l2.l_suppkey"(#7.2)
+                │           │   ├── "l2.l_linenumber"(#7.3)
+                │           │   ├── "l2.l_quantity"(#7.4)
+                │           │   ├── "l2.l_extendedprice"(#7.5)
+                │           │   ├── "l2.l_discount"(#7.6)
+                │           │   ├── "l2.l_tax"(#7.7)
+                │           │   ├── "l2.l_returnflag"(#7.8)
+                │           │   ├── "l2.l_linestatus"(#7.9)
+                │           │   ├── "l2.l_shipdate"(#7.10)
+                │           │   ├── "l2.l_commitdate"(#7.11)
+                │           │   ├── "l2.l_receiptdate"(#7.12)
+                │           │   ├── "l2.l_shipinstruct"(#7.13)
+                │           │   ├── "l2.l_shipmode"(#7.14)
+                │           │   └── "l2.l_comment"(#7.15)
+                │           ├── (.output_columns):
+                │           │   ┌── "__#8.l_comment"(#8.15)
+                │           │   ├── "__#8.l_commitdate"(#8.11)
+                │           │   ├── "__#8.l_discount"(#8.6)
+                │           │   ├── "__#8.l_extendedprice"(#8.5)
+                │           │   ├── "__#8.l_linenumber"(#8.3)
+                │           │   ├── "__#8.l_linestatus"(#8.9)
+                │           │   ├── "__#8.l_orderkey"(#8.0)
+                │           │   ├── "__#8.l_partkey"(#8.1)
+                │           │   ├── "__#8.l_quantity"(#8.4)
+                │           │   ├── "__#8.l_receiptdate"(#8.12)
+                │           │   ├── "__#8.l_returnflag"(#8.8)
+                │           │   ├── "__#8.l_shipdate"(#8.10)
+                │           │   ├── "__#8.l_shipinstruct"(#8.13)
+                │           │   ├── "__#8.l_shipmode"(#8.14)
+                │           │   ├── "__#8.l_suppkey"(#8.2)
+                │           │   └── "__#8.l_tax"(#8.7)
+                │           ├── (.cardinality): 0.00
+                │           └── Remap
+                │               ├── .table_index: 7
+                │               ├── (.output_columns):
+                │               │   ┌── "l2.l_comment"(#7.15)
+                │               │   ├── "l2.l_commitdate"(#7.11)
+                │               │   ├── "l2.l_discount"(#7.6)
+                │               │   ├── "l2.l_extendedprice"(#7.5)
+                │               │   ├── "l2.l_linenumber"(#7.3)
+                │               │   ├── "l2.l_linestatus"(#7.9)
+                │               │   ├── "l2.l_orderkey"(#7.0)
+                │               │   ├── "l2.l_partkey"(#7.1)
+                │               │   ├── "l2.l_quantity"(#7.4)
+                │               │   ├── "l2.l_receiptdate"(#7.12)
+                │               │   ├── "l2.l_returnflag"(#7.8)
+                │               │   ├── "l2.l_shipdate"(#7.10)
+                │               │   ├── "l2.l_shipinstruct"(#7.13)
+                │               │   ├── "l2.l_shipmode"(#7.14)
+                │               │   ├── "l2.l_suppkey"(#7.2)
+                │               │   └── "l2.l_tax"(#7.7)
+                │               ├── (.cardinality): 0.00
+                │               └── Get
+                │                   ├── .data_source_id: 8
+                │                   ├── .table_index: 6
+                │                   ├── .implementation: None
+                │                   ├── (.output_columns):
+                │                   │   ┌── "lineitem.l_comment"(#6.15)
+                │                   │   ├── "lineitem.l_commitdate"(#6.11)
+                │                   │   ├── "lineitem.l_discount"(#6.6)
+                │                   │   ├── "lineitem.l_extendedprice"(#6.5)
+                │                   │   ├── "lineitem.l_linenumber"(#6.3)
+                │                   │   ├── "lineitem.l_linestatus"(#6.9)
+                │                   │   ├── "lineitem.l_orderkey"(#6.0)
+                │                   │   ├── "lineitem.l_partkey"(#6.1)
+                │                   │   ├── "lineitem.l_quantity"(#6.4)
+                │                   │   ├── "lineitem.l_receiptdate"(#6.12)
+                │                   │   ├── "lineitem.l_returnflag"(#6.8)
+                │                   │   ├── "lineitem.l_shipdate"(#6.10)
+                │                   │   ├── "lineitem.l_shipinstruct"(#6.13)
+                │                   │   ├── "lineitem.l_shipmode"(#6.14)
+                │                   │   ├── "lineitem.l_suppkey"(#6.2)
+                │                   │   └── "lineitem.l_tax"(#6.7)
+                │                   └── (.cardinality): 0.00
+                └── Remap
+                    ├── .table_index: 13
                     ├── (.output_columns):
-                    │   ┌── "l1.l_comment"(#3.15)
-                    │   ├── "l1.l_commitdate"(#3.11)
-                    │   ├── "l1.l_discount"(#3.6)
-                    │   ├── "l1.l_extendedprice"(#3.5)
-                    │   ├── "l1.l_linenumber"(#3.3)
-                    │   ├── "l1.l_linestatus"(#3.9)
-                    │   ├── "l1.l_orderkey"(#3.0)
-                    │   ├── "l1.l_partkey"(#3.1)
-                    │   ├── "l1.l_quantity"(#3.4)
-                    │   ├── "l1.l_receiptdate"(#3.12)
-                    │   ├── "l1.l_returnflag"(#3.8)
-                    │   ├── "l1.l_shipdate"(#3.10)
-                    │   ├── "l1.l_shipinstruct"(#3.13)
-                    │   ├── "l1.l_shipmode"(#3.14)
-                    │   ├── "l1.l_suppkey"(#3.2)
-                    │   ├── "l1.l_tax"(#3.7)
-                    │   ├── "nation.n_name"(#5.1)
-                    │   ├── "nation.n_nationkey"(#5.0)
-                    │   ├── "orders.o_orderkey"(#4.0)
-                    │   ├── "orders.o_orderstatus"(#4.2)
-                    │   ├── "supplier.s_name"(#1.1)
-                    │   ├── "supplier.s_nationkey"(#1.3)
-                    │   └── "supplier.s_suppkey"(#1.0)
+                    │   ┌── "__correlated_sq_2.l_comment"(#13.15)
+                    │   ├── "__correlated_sq_2.l_commitdate"(#13.11)
+                    │   ├── "__correlated_sq_2.l_discount"(#13.6)
+                    │   ├── "__correlated_sq_2.l_extendedprice"(#13.5)
+                    │   ├── "__correlated_sq_2.l_linenumber"(#13.3)
+                    │   ├── "__correlated_sq_2.l_linestatus"(#13.9)
+                    │   ├── "__correlated_sq_2.l_orderkey"(#13.0)
+                    │   ├── "__correlated_sq_2.l_partkey"(#13.1)
+                    │   ├── "__correlated_sq_2.l_quantity"(#13.4)
+                    │   ├── "__correlated_sq_2.l_receiptdate"(#13.12)
+                    │   ├── "__correlated_sq_2.l_returnflag"(#13.8)
+                    │   ├── "__correlated_sq_2.l_shipdate"(#13.10)
+                    │   ├── "__correlated_sq_2.l_shipinstruct"(#13.13)
+                    │   ├── "__correlated_sq_2.l_shipmode"(#13.14)
+                    │   ├── "__correlated_sq_2.l_suppkey"(#13.2)
+                    │   └── "__correlated_sq_2.l_tax"(#13.7)
                     ├── (.cardinality): 0.00
-                    ├── Join
-                    │   ├── .join_type: LeftSemi
-                    │   ├── .implementation: None
-                    │   ├── .join_cond: ("l1.l_orderkey"(#3.0) = "__correlated_sq_1.l_orderkey"(#9.0)) AND ("__correlated_sq_1.l_suppkey"(#9.2) != "l1.l_suppkey"(#3.2))
-                    │   ├── (.output_columns):
-                    │   │   ┌── "l1.l_comment"(#3.15)
-                    │   │   ├── "l1.l_commitdate"(#3.11)
-                    │   │   ├── "l1.l_discount"(#3.6)
-                    │   │   ├── "l1.l_extendedprice"(#3.5)
-                    │   │   ├── "l1.l_linenumber"(#3.3)
-                    │   │   ├── "l1.l_linestatus"(#3.9)
-                    │   │   ├── "l1.l_orderkey"(#3.0)
-                    │   │   ├── "l1.l_partkey"(#3.1)
-                    │   │   ├── "l1.l_quantity"(#3.4)
-                    │   │   ├── "l1.l_receiptdate"(#3.12)
-                    │   │   ├── "l1.l_returnflag"(#3.8)
-                    │   │   ├── "l1.l_shipdate"(#3.10)
-                    │   │   ├── "l1.l_shipinstruct"(#3.13)
-                    │   │   ├── "l1.l_shipmode"(#3.14)
-                    │   │   ├── "l1.l_suppkey"(#3.2)
-                    │   │   ├── "l1.l_tax"(#3.7)
-                    │   │   ├── "nation.n_name"(#5.1)
-                    │   │   ├── "nation.n_nationkey"(#5.0)
-                    │   │   ├── "orders.o_orderkey"(#4.0)
-                    │   │   ├── "orders.o_orderstatus"(#4.2)
-                    │   │   ├── "supplier.s_name"(#1.1)
-                    │   │   ├── "supplier.s_nationkey"(#1.3)
-                    │   │   └── "supplier.s_suppkey"(#1.0)
-                    │   ├── (.cardinality): 0.00
-                    │   ├── Join
-                    │   │   ├── .join_type: Inner
-                    │   │   ├── .implementation: None
-                    │   │   ├── .join_cond: true::boolean
-                    │   │   ├── (.output_columns):
-                    │   │   │   ┌── "l1.l_comment"(#3.15)
-                    │   │   │   ├── "l1.l_commitdate"(#3.11)
-                    │   │   │   ├── "l1.l_discount"(#3.6)
-                    │   │   │   ├── "l1.l_extendedprice"(#3.5)
-                    │   │   │   ├── "l1.l_linenumber"(#3.3)
-                    │   │   │   ├── "l1.l_linestatus"(#3.9)
-                    │   │   │   ├── "l1.l_orderkey"(#3.0)
-                    │   │   │   ├── "l1.l_partkey"(#3.1)
-                    │   │   │   ├── "l1.l_quantity"(#3.4)
-                    │   │   │   ├── "l1.l_receiptdate"(#3.12)
-                    │   │   │   ├── "l1.l_returnflag"(#3.8)
-                    │   │   │   ├── "l1.l_shipdate"(#3.10)
-                    │   │   │   ├── "l1.l_shipinstruct"(#3.13)
-                    │   │   │   ├── "l1.l_shipmode"(#3.14)
-                    │   │   │   ├── "l1.l_suppkey"(#3.2)
-                    │   │   │   ├── "l1.l_tax"(#3.7)
-                    │   │   │   ├── "nation.n_name"(#5.1)
-                    │   │   │   ├── "nation.n_nationkey"(#5.0)
-                    │   │   │   ├── "orders.o_orderkey"(#4.0)
-                    │   │   │   ├── "orders.o_orderstatus"(#4.2)
-                    │   │   │   ├── "supplier.s_name"(#1.1)
-                    │   │   │   ├── "supplier.s_nationkey"(#1.3)
-                    │   │   │   └── "supplier.s_suppkey"(#1.0)
-                    │   │   ├── (.cardinality): 0.00
-                    │   │   ├── Join
-                    │   │   │   ├── .join_type: Inner
-                    │   │   │   ├── .implementation: None
-                    │   │   │   ├── .join_cond: true::boolean
-                    │   │   │   ├── (.output_columns):
-                    │   │   │   │   ┌── "l1.l_comment"(#3.15)
-                    │   │   │   │   ├── "l1.l_commitdate"(#3.11)
-                    │   │   │   │   ├── "l1.l_discount"(#3.6)
-                    │   │   │   │   ├── "l1.l_extendedprice"(#3.5)
-                    │   │   │   │   ├── "l1.l_linenumber"(#3.3)
-                    │   │   │   │   ├── "l1.l_linestatus"(#3.9)
-                    │   │   │   │   ├── "l1.l_orderkey"(#3.0)
-                    │   │   │   │   ├── "l1.l_partkey"(#3.1)
-                    │   │   │   │   ├── "l1.l_quantity"(#3.4)
-                    │   │   │   │   ├── "l1.l_receiptdate"(#3.12)
-                    │   │   │   │   ├── "l1.l_returnflag"(#3.8)
-                    │   │   │   │   ├── "l1.l_shipdate"(#3.10)
-                    │   │   │   │   ├── "l1.l_shipinstruct"(#3.13)
-                    │   │   │   │   ├── "l1.l_shipmode"(#3.14)
-                    │   │   │   │   ├── "l1.l_suppkey"(#3.2)
-                    │   │   │   │   ├── "l1.l_tax"(#3.7)
-                    │   │   │   │   ├── "orders.o_orderkey"(#4.0)
-                    │   │   │   │   ├── "orders.o_orderstatus"(#4.2)
-                    │   │   │   │   ├── "supplier.s_name"(#1.1)
-                    │   │   │   │   ├── "supplier.s_nationkey"(#1.3)
-                    │   │   │   │   └── "supplier.s_suppkey"(#1.0)
-                    │   │   │   ├── (.cardinality): 0.00
-                    │   │   │   ├── Join
-                    │   │   │   │   ├── .join_type: Inner
-                    │   │   │   │   ├── .implementation: None
-                    │   │   │   │   ├── .join_cond: true::boolean
-                    │   │   │   │   ├── (.output_columns):
-                    │   │   │   │   │   ┌── "l1.l_comment"(#3.15)
-                    │   │   │   │   │   ├── "l1.l_commitdate"(#3.11)
-                    │   │   │   │   │   ├── "l1.l_discount"(#3.6)
-                    │   │   │   │   │   ├── "l1.l_extendedprice"(#3.5)
-                    │   │   │   │   │   ├── "l1.l_linenumber"(#3.3)
-                    │   │   │   │   │   ├── "l1.l_linestatus"(#3.9)
-                    │   │   │   │   │   ├── "l1.l_orderkey"(#3.0)
-                    │   │   │   │   │   ├── "l1.l_partkey"(#3.1)
-                    │   │   │   │   │   ├── "l1.l_quantity"(#3.4)
-                    │   │   │   │   │   ├── "l1.l_receiptdate"(#3.12)
-                    │   │   │   │   │   ├── "l1.l_returnflag"(#3.8)
-                    │   │   │   │   │   ├── "l1.l_shipdate"(#3.10)
-                    │   │   │   │   │   ├── "l1.l_shipinstruct"(#3.13)
-                    │   │   │   │   │   ├── "l1.l_shipmode"(#3.14)
-                    │   │   │   │   │   ├── "l1.l_suppkey"(#3.2)
-                    │   │   │   │   │   ├── "l1.l_tax"(#3.7)
-                    │   │   │   │   │   ├── "supplier.s_name"(#1.1)
-                    │   │   │   │   │   ├── "supplier.s_nationkey"(#1.3)
-                    │   │   │   │   │   └── "supplier.s_suppkey"(#1.0)
-                    │   │   │   │   ├── (.cardinality): 0.00
-                    │   │   │   │   ├── Get { .data_source_id: 4, .table_index: 1, .implementation: None, (.output_columns): [ "supplier.s_name"(#1.1), "supplier.s_nationkey"(#1.3), "supplier.s_suppkey"(#1.0) ], (.cardinality): 0.00 }
-                    │   │   │   │   └── Remap
-                    │   │   │   │       ├── .table_index: 3
-                    │   │   │   │       ├── (.output_columns):
-                    │   │   │   │       │   ┌── "l1.l_comment"(#3.15)
-                    │   │   │   │       │   ├── "l1.l_commitdate"(#3.11)
-                    │   │   │   │       │   ├── "l1.l_discount"(#3.6)
-                    │   │   │   │       │   ├── "l1.l_extendedprice"(#3.5)
-                    │   │   │   │       │   ├── "l1.l_linenumber"(#3.3)
-                    │   │   │   │       │   ├── "l1.l_linestatus"(#3.9)
-                    │   │   │   │       │   ├── "l1.l_orderkey"(#3.0)
-                    │   │   │   │       │   ├── "l1.l_partkey"(#3.1)
-                    │   │   │   │       │   ├── "l1.l_quantity"(#3.4)
-                    │   │   │   │       │   ├── "l1.l_receiptdate"(#3.12)
-                    │   │   │   │       │   ├── "l1.l_returnflag"(#3.8)
-                    │   │   │   │       │   ├── "l1.l_shipdate"(#3.10)
-                    │   │   │   │       │   ├── "l1.l_shipinstruct"(#3.13)
-                    │   │   │   │       │   ├── "l1.l_shipmode"(#3.14)
-                    │   │   │   │       │   ├── "l1.l_suppkey"(#3.2)
-                    │   │   │   │       │   └── "l1.l_tax"(#3.7)
-                    │   │   │   │       ├── (.cardinality): 0.00
-                    │   │   │   │       └── Get
-                    │   │   │   │           ├── .data_source_id: 8
-                    │   │   │   │           ├── .table_index: 2
-                    │   │   │   │           ├── .implementation: None
-                    │   │   │   │           ├── (.output_columns):
-                    │   │   │   │           │   ┌── "lineitem.l_comment"(#2.15)
-                    │   │   │   │           │   ├── "lineitem.l_commitdate"(#2.11)
-                    │   │   │   │           │   ├── "lineitem.l_discount"(#2.6)
-                    │   │   │   │           │   ├── "lineitem.l_extendedprice"(#2.5)
-                    │   │   │   │           │   ├── "lineitem.l_linenumber"(#2.3)
-                    │   │   │   │           │   ├── "lineitem.l_linestatus"(#2.9)
-                    │   │   │   │           │   ├── "lineitem.l_orderkey"(#2.0)
-                    │   │   │   │           │   ├── "lineitem.l_partkey"(#2.1)
-                    │   │   │   │           │   ├── "lineitem.l_quantity"(#2.4)
-                    │   │   │   │           │   ├── "lineitem.l_receiptdate"(#2.12)
-                    │   │   │   │           │   ├── "lineitem.l_returnflag"(#2.8)
-                    │   │   │   │           │   ├── "lineitem.l_shipdate"(#2.10)
-                    │   │   │   │           │   ├── "lineitem.l_shipinstruct"(#2.13)
-                    │   │   │   │           │   ├── "lineitem.l_shipmode"(#2.14)
-                    │   │   │   │           │   ├── "lineitem.l_suppkey"(#2.2)
-                    │   │   │   │           │   └── "lineitem.l_tax"(#2.7)
-                    │   │   │   │           └── (.cardinality): 0.00
-                    │   │   │   └── Get { .data_source_id: 7, .table_index: 4, .implementation: None, (.output_columns): [ "orders.o_orderkey"(#4.0), "orders.o_orderstatus"(#4.2) ], (.cardinality): 0.00 }
-                    │   │   └── Get { .data_source_id: 1, .table_index: 5, .implementation: None, (.output_columns): [ "nation.n_name"(#5.1), "nation.n_nationkey"(#5.0) ], (.cardinality): 0.00 }
-                    │   └── Remap
-                    │       ├── .table_index: 9
-                    │       ├── (.output_columns):
-                    │       │   ┌── "__correlated_sq_1.l_comment"(#9.15)
-                    │       │   ├── "__correlated_sq_1.l_commitdate"(#9.11)
-                    │       │   ├── "__correlated_sq_1.l_discount"(#9.6)
-                    │       │   ├── "__correlated_sq_1.l_extendedprice"(#9.5)
-                    │       │   ├── "__correlated_sq_1.l_linenumber"(#9.3)
-                    │       │   ├── "__correlated_sq_1.l_linestatus"(#9.9)
-                    │       │   ├── "__correlated_sq_1.l_orderkey"(#9.0)
-                    │       │   ├── "__correlated_sq_1.l_partkey"(#9.1)
-                    │       │   ├── "__correlated_sq_1.l_quantity"(#9.4)
-                    │       │   ├── "__correlated_sq_1.l_receiptdate"(#9.12)
-                    │       │   ├── "__correlated_sq_1.l_returnflag"(#9.8)
-                    │       │   ├── "__correlated_sq_1.l_shipdate"(#9.10)
-                    │       │   ├── "__correlated_sq_1.l_shipinstruct"(#9.13)
-                    │       │   ├── "__correlated_sq_1.l_shipmode"(#9.14)
-                    │       │   ├── "__correlated_sq_1.l_suppkey"(#9.2)
-                    │       │   └── "__correlated_sq_1.l_tax"(#9.7)
-                    │       ├── (.cardinality): 0.00
-                    │       └── Project
-                    │           ├── .table_index: 8
-                    │           ├── .projections:
-                    │           │   ┌── "l2.l_orderkey"(#7.0)
-                    │           │   ├── "l2.l_partkey"(#7.1)
-                    │           │   ├── "l2.l_suppkey"(#7.2)
-                    │           │   ├── "l2.l_linenumber"(#7.3)
-                    │           │   ├── "l2.l_quantity"(#7.4)
-                    │           │   ├── "l2.l_extendedprice"(#7.5)
-                    │           │   ├── "l2.l_discount"(#7.6)
-                    │           │   ├── "l2.l_tax"(#7.7)
-                    │           │   ├── "l2.l_returnflag"(#7.8)
-                    │           │   ├── "l2.l_linestatus"(#7.9)
-                    │           │   ├── "l2.l_shipdate"(#7.10)
-                    │           │   ├── "l2.l_commitdate"(#7.11)
-                    │           │   ├── "l2.l_receiptdate"(#7.12)
-                    │           │   ├── "l2.l_shipinstruct"(#7.13)
-                    │           │   ├── "l2.l_shipmode"(#7.14)
-                    │           │   └── "l2.l_comment"(#7.15)
-                    │           ├── (.output_columns):
-                    │           │   ┌── "__#8.l_comment"(#8.15)
-                    │           │   ├── "__#8.l_commitdate"(#8.11)
-                    │           │   ├── "__#8.l_discount"(#8.6)
-                    │           │   ├── "__#8.l_extendedprice"(#8.5)
-                    │           │   ├── "__#8.l_linenumber"(#8.3)
-                    │           │   ├── "__#8.l_linestatus"(#8.9)
-                    │           │   ├── "__#8.l_orderkey"(#8.0)
-                    │           │   ├── "__#8.l_partkey"(#8.1)
-                    │           │   ├── "__#8.l_quantity"(#8.4)
-                    │           │   ├── "__#8.l_receiptdate"(#8.12)
-                    │           │   ├── "__#8.l_returnflag"(#8.8)
-                    │           │   ├── "__#8.l_shipdate"(#8.10)
-                    │           │   ├── "__#8.l_shipinstruct"(#8.13)
-                    │           │   ├── "__#8.l_shipmode"(#8.14)
-                    │           │   ├── "__#8.l_suppkey"(#8.2)
-                    │           │   └── "__#8.l_tax"(#8.7)
-                    │           ├── (.cardinality): 0.00
-                    │           └── Remap
-                    │               ├── .table_index: 7
-                    │               ├── (.output_columns):
-                    │               │   ┌── "l2.l_comment"(#7.15)
-                    │               │   ├── "l2.l_commitdate"(#7.11)
-                    │               │   ├── "l2.l_discount"(#7.6)
-                    │               │   ├── "l2.l_extendedprice"(#7.5)
-                    │               │   ├── "l2.l_linenumber"(#7.3)
-                    │               │   ├── "l2.l_linestatus"(#7.9)
-                    │               │   ├── "l2.l_orderkey"(#7.0)
-                    │               │   ├── "l2.l_partkey"(#7.1)
-                    │               │   ├── "l2.l_quantity"(#7.4)
-                    │               │   ├── "l2.l_receiptdate"(#7.12)
-                    │               │   ├── "l2.l_returnflag"(#7.8)
-                    │               │   ├── "l2.l_shipdate"(#7.10)
-                    │               │   ├── "l2.l_shipinstruct"(#7.13)
-                    │               │   ├── "l2.l_shipmode"(#7.14)
-                    │               │   ├── "l2.l_suppkey"(#7.2)
-                    │               │   └── "l2.l_tax"(#7.7)
-                    │               ├── (.cardinality): 0.00
-                    │               └── Get
-                    │                   ├── .data_source_id: 8
-                    │                   ├── .table_index: 6
-                    │                   ├── .implementation: None
-                    │                   ├── (.output_columns):
-                    │                   │   ┌── "lineitem.l_comment"(#6.15)
-                    │                   │   ├── "lineitem.l_commitdate"(#6.11)
-                    │                   │   ├── "lineitem.l_discount"(#6.6)
-                    │                   │   ├── "lineitem.l_extendedprice"(#6.5)
-                    │                   │   ├── "lineitem.l_linenumber"(#6.3)
-                    │                   │   ├── "lineitem.l_linestatus"(#6.9)
-                    │                   │   ├── "lineitem.l_orderkey"(#6.0)
-                    │                   │   ├── "lineitem.l_partkey"(#6.1)
-                    │                   │   ├── "lineitem.l_quantity"(#6.4)
-                    │                   │   ├── "lineitem.l_receiptdate"(#6.12)
-                    │                   │   ├── "lineitem.l_returnflag"(#6.8)
-                    │                   │   ├── "lineitem.l_shipdate"(#6.10)
-                    │                   │   ├── "lineitem.l_shipinstruct"(#6.13)
-                    │                   │   ├── "lineitem.l_shipmode"(#6.14)
-                    │                   │   ├── "lineitem.l_suppkey"(#6.2)
-                    │                   │   └── "lineitem.l_tax"(#6.7)
-                    │                   └── (.cardinality): 0.00
-                    └── Remap
-                        ├── .table_index: 13
+                    └── Project
+                        ├── .table_index: 12
+                        ├── .projections:
+                        │   ┌── "l3.l_orderkey"(#11.0)
+                        │   ├── "l3.l_partkey"(#11.1)
+                        │   ├── "l3.l_suppkey"(#11.2)
+                        │   ├── "l3.l_linenumber"(#11.3)
+                        │   ├── "l3.l_quantity"(#11.4)
+                        │   ├── "l3.l_extendedprice"(#11.5)
+                        │   ├── "l3.l_discount"(#11.6)
+                        │   ├── "l3.l_tax"(#11.7)
+                        │   ├── "l3.l_returnflag"(#11.8)
+                        │   ├── "l3.l_linestatus"(#11.9)
+                        │   ├── "l3.l_shipdate"(#11.10)
+                        │   ├── "l3.l_commitdate"(#11.11)
+                        │   ├── "l3.l_receiptdate"(#11.12)
+                        │   ├── "l3.l_shipinstruct"(#11.13)
+                        │   ├── "l3.l_shipmode"(#11.14)
+                        │   └── "l3.l_comment"(#11.15)
                         ├── (.output_columns):
-                        │   ┌── "__correlated_sq_2.l_comment"(#13.15)
-                        │   ├── "__correlated_sq_2.l_commitdate"(#13.11)
-                        │   ├── "__correlated_sq_2.l_discount"(#13.6)
-                        │   ├── "__correlated_sq_2.l_extendedprice"(#13.5)
-                        │   ├── "__correlated_sq_2.l_linenumber"(#13.3)
-                        │   ├── "__correlated_sq_2.l_linestatus"(#13.9)
-                        │   ├── "__correlated_sq_2.l_orderkey"(#13.0)
-                        │   ├── "__correlated_sq_2.l_partkey"(#13.1)
-                        │   ├── "__correlated_sq_2.l_quantity"(#13.4)
-                        │   ├── "__correlated_sq_2.l_receiptdate"(#13.12)
-                        │   ├── "__correlated_sq_2.l_returnflag"(#13.8)
-                        │   ├── "__correlated_sq_2.l_shipdate"(#13.10)
-                        │   ├── "__correlated_sq_2.l_shipinstruct"(#13.13)
-                        │   ├── "__correlated_sq_2.l_shipmode"(#13.14)
-                        │   ├── "__correlated_sq_2.l_suppkey"(#13.2)
-                        │   └── "__correlated_sq_2.l_tax"(#13.7)
+                        │   ┌── "__#12.l_comment"(#12.15)
+                        │   ├── "__#12.l_commitdate"(#12.11)
+                        │   ├── "__#12.l_discount"(#12.6)
+                        │   ├── "__#12.l_extendedprice"(#12.5)
+                        │   ├── "__#12.l_linenumber"(#12.3)
+                        │   ├── "__#12.l_linestatus"(#12.9)
+                        │   ├── "__#12.l_orderkey"(#12.0)
+                        │   ├── "__#12.l_partkey"(#12.1)
+                        │   ├── "__#12.l_quantity"(#12.4)
+                        │   ├── "__#12.l_receiptdate"(#12.12)
+                        │   ├── "__#12.l_returnflag"(#12.8)
+                        │   ├── "__#12.l_shipdate"(#12.10)
+                        │   ├── "__#12.l_shipinstruct"(#12.13)
+                        │   ├── "__#12.l_shipmode"(#12.14)
+                        │   ├── "__#12.l_suppkey"(#12.2)
+                        │   └── "__#12.l_tax"(#12.7)
                         ├── (.cardinality): 0.00
-                        └── Project
-                            ├── .table_index: 12
-                            ├── .projections:
-                            │   ┌── "l3.l_orderkey"(#11.0)
-                            │   ├── "l3.l_partkey"(#11.1)
-                            │   ├── "l3.l_suppkey"(#11.2)
-                            │   ├── "l3.l_linenumber"(#11.3)
-                            │   ├── "l3.l_quantity"(#11.4)
-                            │   ├── "l3.l_extendedprice"(#11.5)
-                            │   ├── "l3.l_discount"(#11.6)
-                            │   ├── "l3.l_tax"(#11.7)
-                            │   ├── "l3.l_returnflag"(#11.8)
-                            │   ├── "l3.l_linestatus"(#11.9)
-                            │   ├── "l3.l_shipdate"(#11.10)
+                        └── Select
+                            ├── .predicate: "l3.l_receiptdate"(#11.12) > "l3.l_commitdate"(#11.11)
+                            ├── (.output_columns):
+                            │   ┌── "l3.l_comment"(#11.15)
                             │   ├── "l3.l_commitdate"(#11.11)
+                            │   ├── "l3.l_discount"(#11.6)
+                            │   ├── "l3.l_extendedprice"(#11.5)
+                            │   ├── "l3.l_linenumber"(#11.3)
+                            │   ├── "l3.l_linestatus"(#11.9)
+                            │   ├── "l3.l_orderkey"(#11.0)
+                            │   ├── "l3.l_partkey"(#11.1)
+                            │   ├── "l3.l_quantity"(#11.4)
                             │   ├── "l3.l_receiptdate"(#11.12)
+                            │   ├── "l3.l_returnflag"(#11.8)
+                            │   ├── "l3.l_shipdate"(#11.10)
                             │   ├── "l3.l_shipinstruct"(#11.13)
                             │   ├── "l3.l_shipmode"(#11.14)
-                            │   └── "l3.l_comment"(#11.15)
-                            ├── (.output_columns):
-                            │   ┌── "__#12.l_comment"(#12.15)
-                            │   ├── "__#12.l_commitdate"(#12.11)
-                            │   ├── "__#12.l_discount"(#12.6)
-                            │   ├── "__#12.l_extendedprice"(#12.5)
-                            │   ├── "__#12.l_linenumber"(#12.3)
-                            │   ├── "__#12.l_linestatus"(#12.9)
-                            │   ├── "__#12.l_orderkey"(#12.0)
-                            │   ├── "__#12.l_partkey"(#12.1)
-                            │   ├── "__#12.l_quantity"(#12.4)
-                            │   ├── "__#12.l_receiptdate"(#12.12)
-                            │   ├── "__#12.l_returnflag"(#12.8)
-                            │   ├── "__#12.l_shipdate"(#12.10)
-                            │   ├── "__#12.l_shipinstruct"(#12.13)
-                            │   ├── "__#12.l_shipmode"(#12.14)
-                            │   ├── "__#12.l_suppkey"(#12.2)
-                            │   └── "__#12.l_tax"(#12.7)
+                            │   ├── "l3.l_suppkey"(#11.2)
+                            │   └── "l3.l_tax"(#11.7)
                             ├── (.cardinality): 0.00
-                            └── Select
-                                ├── .predicate: "l3.l_receiptdate"(#11.12) > "l3.l_commitdate"(#11.11)
+                            └── Remap
+                                ├── .table_index: 11
                                 ├── (.output_columns):
                                 │   ┌── "l3.l_comment"(#11.15)
                                 │   ├── "l3.l_commitdate"(#11.11)
@@ -940,47 +987,27 @@ Limit { .skip: 0::bigint, .fetch: 100::bigint, (.output_columns): [ "__#16.numwa
                                 │   ├── "l3.l_suppkey"(#11.2)
                                 │   └── "l3.l_tax"(#11.7)
                                 ├── (.cardinality): 0.00
-                                └── Remap
-                                    ├── .table_index: 11
+                                └── Get
+                                    ├── .data_source_id: 8
+                                    ├── .table_index: 10
+                                    ├── .implementation: None
                                     ├── (.output_columns):
-                                    │   ┌── "l3.l_comment"(#11.15)
-                                    │   ├── "l3.l_commitdate"(#11.11)
-                                    │   ├── "l3.l_discount"(#11.6)
-                                    │   ├── "l3.l_extendedprice"(#11.5)
-                                    │   ├── "l3.l_linenumber"(#11.3)
-                                    │   ├── "l3.l_linestatus"(#11.9)
-                                    │   ├── "l3.l_orderkey"(#11.0)
-                                    │   ├── "l3.l_partkey"(#11.1)
-                                    │   ├── "l3.l_quantity"(#11.4)
-                                    │   ├── "l3.l_receiptdate"(#11.12)
-                                    │   ├── "l3.l_returnflag"(#11.8)
-                                    │   ├── "l3.l_shipdate"(#11.10)
-                                    │   ├── "l3.l_shipinstruct"(#11.13)
-                                    │   ├── "l3.l_shipmode"(#11.14)
-                                    │   ├── "l3.l_suppkey"(#11.2)
-                                    │   └── "l3.l_tax"(#11.7)
-                                    ├── (.cardinality): 0.00
-                                    └── Get
-                                        ├── .data_source_id: 8
-                                        ├── .table_index: 10
-                                        ├── .implementation: None
-                                        ├── (.output_columns):
-                                        │   ┌── "lineitem.l_comment"(#10.15)
-                                        │   ├── "lineitem.l_commitdate"(#10.11)
-                                        │   ├── "lineitem.l_discount"(#10.6)
-                                        │   ├── "lineitem.l_extendedprice"(#10.5)
-                                        │   ├── "lineitem.l_linenumber"(#10.3)
-                                        │   ├── "lineitem.l_linestatus"(#10.9)
-                                        │   ├── "lineitem.l_orderkey"(#10.0)
-                                        │   ├── "lineitem.l_partkey"(#10.1)
-                                        │   ├── "lineitem.l_quantity"(#10.4)
-                                        │   ├── "lineitem.l_receiptdate"(#10.12)
-                                        │   ├── "lineitem.l_returnflag"(#10.8)
-                                        │   ├── "lineitem.l_shipdate"(#10.10)
-                                        │   ├── "lineitem.l_shipinstruct"(#10.13)
-                                        │   ├── "lineitem.l_shipmode"(#10.14)
-                                        │   ├── "lineitem.l_suppkey"(#10.2)
-                                        │   └── "lineitem.l_tax"(#10.7)
-                                        └── (.cardinality): 0.00
+                                    │   ┌── "lineitem.l_comment"(#10.15)
+                                    │   ├── "lineitem.l_commitdate"(#10.11)
+                                    │   ├── "lineitem.l_discount"(#10.6)
+                                    │   ├── "lineitem.l_extendedprice"(#10.5)
+                                    │   ├── "lineitem.l_linenumber"(#10.3)
+                                    │   ├── "lineitem.l_linestatus"(#10.9)
+                                    │   ├── "lineitem.l_orderkey"(#10.0)
+                                    │   ├── "lineitem.l_partkey"(#10.1)
+                                    │   ├── "lineitem.l_quantity"(#10.4)
+                                    │   ├── "lineitem.l_receiptdate"(#10.12)
+                                    │   ├── "lineitem.l_returnflag"(#10.8)
+                                    │   ├── "lineitem.l_shipdate"(#10.10)
+                                    │   ├── "lineitem.l_shipinstruct"(#10.13)
+                                    │   ├── "lineitem.l_shipmode"(#10.14)
+                                    │   ├── "lineitem.l_suppkey"(#10.2)
+                                    │   └── "lineitem.l_tax"(#10.7)
+                                    └── (.cardinality): 0.00
 */
 

--- a/tests/sqlplannertest/tests/tpch/q22.planner.sql
+++ b/tests/sqlplannertest/tests/tpch/q22.planner.sql
@@ -135,63 +135,63 @@ EnforcerSort { tuple_ordering: [(#15.0, Asc)], (.output_columns): [ "__#15.cntry
                     ├── .join_cond: CAST ("customer.c_acctbal"(#1.5) AS Decimal128(19, 6)) > "__scalar_sq_2.avg(customer.c_acctbal)"(#9.0)
                     ├── (.output_columns): [ "__scalar_sq_2.avg(customer.c_acctbal)"(#9.0), "customer.c_acctbal"(#1.5), "customer.c_custkey"(#1.0), "customer.c_phone"(#1.4) ]
                     ├── (.cardinality): 0.00
-                    ├── Select
-                    │   ├── .predicate: substr("customer.c_phone"(#1.4), 1::bigint, 2::bigint) IN ['13'::utf8_view, '31'::utf8_view, '23'::utf8_view, '29'::utf8_view, '30'::utf8_view, '18'::utf8_view, '17'::utf8_view]
-                    │   ├── (.output_columns): [ "customer.c_acctbal"(#1.5), "customer.c_custkey"(#1.0), "customer.c_phone"(#1.4) ]
-                    │   ├── (.cardinality): 0.00
-                    │   └── Join { .join_type: LeftAnti, .implementation: None, .join_cond: "customer.c_custkey"(#1.0) = "__correlated_sq_1.o_custkey"(#4.1), (.output_columns): [ "customer.c_acctbal"(#1.5), "customer.c_custkey"(#1.0), "customer.c_phone"(#1.4) ], (.cardinality): 0.00 }
-                    │       ├── Get { .data_source_id: 6, .table_index: 1, .implementation: None, (.output_columns): [ "customer.c_acctbal"(#1.5), "customer.c_custkey"(#1.0), "customer.c_phone"(#1.4) ], (.cardinality): 0.00 }
-                    │       └── Remap
-                    │           ├── .table_index: 4
+                    ├── Join { .join_type: LeftAnti, .implementation: None, .join_cond: "customer.c_custkey"(#1.0) = "__correlated_sq_1.o_custkey"(#4.1), (.output_columns): [ "customer.c_acctbal"(#1.5), "customer.c_custkey"(#1.0), "customer.c_phone"(#1.4) ], (.cardinality): 0.00 }
+                    │   ├── Select
+                    │   │   ├── .predicate: substr("customer.c_phone"(#1.4), 1::bigint, 2::bigint) IN ['13'::utf8_view, '31'::utf8_view, '23'::utf8_view, '29'::utf8_view, '30'::utf8_view, '18'::utf8_view, '17'::utf8_view]
+                    │   │   ├── (.output_columns): [ "customer.c_acctbal"(#1.5), "customer.c_custkey"(#1.0), "customer.c_phone"(#1.4) ]
+                    │   │   ├── (.cardinality): 0.00
+                    │   │   └── Get { .data_source_id: 6, .table_index: 1, .implementation: None, (.output_columns): [ "customer.c_acctbal"(#1.5), "customer.c_custkey"(#1.0), "customer.c_phone"(#1.4) ], (.cardinality): 0.00 }
+                    │   └── Remap
+                    │       ├── .table_index: 4
+                    │       ├── (.output_columns):
+                    │       │   ┌── "__correlated_sq_1.o_clerk"(#4.6)
+                    │       │   ├── "__correlated_sq_1.o_comment"(#4.8)
+                    │       │   ├── "__correlated_sq_1.o_custkey"(#4.1)
+                    │       │   ├── "__correlated_sq_1.o_orderdate"(#4.4)
+                    │       │   ├── "__correlated_sq_1.o_orderkey"(#4.0)
+                    │       │   ├── "__correlated_sq_1.o_orderpriority"(#4.5)
+                    │       │   ├── "__correlated_sq_1.o_orderstatus"(#4.2)
+                    │       │   ├── "__correlated_sq_1.o_shippriority"(#4.7)
+                    │       │   └── "__correlated_sq_1.o_totalprice"(#4.3)
+                    │       ├── (.cardinality): 0.00
+                    │       └── Project
+                    │           ├── .table_index: 3
+                    │           ├── .projections:
+                    │           │   ┌── "orders.o_orderkey"(#2.0)
+                    │           │   ├── "orders.o_custkey"(#2.1)
+                    │           │   ├── "orders.o_orderstatus"(#2.2)
+                    │           │   ├── "orders.o_totalprice"(#2.3)
+                    │           │   ├── "orders.o_orderdate"(#2.4)
+                    │           │   ├── "orders.o_orderpriority"(#2.5)
+                    │           │   ├── "orders.o_clerk"(#2.6)
+                    │           │   ├── "orders.o_shippriority"(#2.7)
+                    │           │   └── "orders.o_comment"(#2.8)
                     │           ├── (.output_columns):
-                    │           │   ┌── "__correlated_sq_1.o_clerk"(#4.6)
-                    │           │   ├── "__correlated_sq_1.o_comment"(#4.8)
-                    │           │   ├── "__correlated_sq_1.o_custkey"(#4.1)
-                    │           │   ├── "__correlated_sq_1.o_orderdate"(#4.4)
-                    │           │   ├── "__correlated_sq_1.o_orderkey"(#4.0)
-                    │           │   ├── "__correlated_sq_1.o_orderpriority"(#4.5)
-                    │           │   ├── "__correlated_sq_1.o_orderstatus"(#4.2)
-                    │           │   ├── "__correlated_sq_1.o_shippriority"(#4.7)
-                    │           │   └── "__correlated_sq_1.o_totalprice"(#4.3)
+                    │           │   ┌── "__#3.o_clerk"(#3.6)
+                    │           │   ├── "__#3.o_comment"(#3.8)
+                    │           │   ├── "__#3.o_custkey"(#3.1)
+                    │           │   ├── "__#3.o_orderdate"(#3.4)
+                    │           │   ├── "__#3.o_orderkey"(#3.0)
+                    │           │   ├── "__#3.o_orderpriority"(#3.5)
+                    │           │   ├── "__#3.o_orderstatus"(#3.2)
+                    │           │   ├── "__#3.o_shippriority"(#3.7)
+                    │           │   └── "__#3.o_totalprice"(#3.3)
                     │           ├── (.cardinality): 0.00
-                    │           └── Project
-                    │               ├── .table_index: 3
-                    │               ├── .projections:
-                    │               │   ┌── "orders.o_orderkey"(#2.0)
-                    │               │   ├── "orders.o_custkey"(#2.1)
-                    │               │   ├── "orders.o_orderstatus"(#2.2)
-                    │               │   ├── "orders.o_totalprice"(#2.3)
-                    │               │   ├── "orders.o_orderdate"(#2.4)
-                    │               │   ├── "orders.o_orderpriority"(#2.5)
-                    │               │   ├── "orders.o_clerk"(#2.6)
-                    │               │   ├── "orders.o_shippriority"(#2.7)
-                    │               │   └── "orders.o_comment"(#2.8)
+                    │           └── Get
+                    │               ├── .data_source_id: 7
+                    │               ├── .table_index: 2
+                    │               ├── .implementation: None
                     │               ├── (.output_columns):
-                    │               │   ┌── "__#3.o_clerk"(#3.6)
-                    │               │   ├── "__#3.o_comment"(#3.8)
-                    │               │   ├── "__#3.o_custkey"(#3.1)
-                    │               │   ├── "__#3.o_orderdate"(#3.4)
-                    │               │   ├── "__#3.o_orderkey"(#3.0)
-                    │               │   ├── "__#3.o_orderpriority"(#3.5)
-                    │               │   ├── "__#3.o_orderstatus"(#3.2)
-                    │               │   ├── "__#3.o_shippriority"(#3.7)
-                    │               │   └── "__#3.o_totalprice"(#3.3)
-                    │               ├── (.cardinality): 0.00
-                    │               └── Get
-                    │                   ├── .data_source_id: 7
-                    │                   ├── .table_index: 2
-                    │                   ├── .implementation: None
-                    │                   ├── (.output_columns):
-                    │                   │   ┌── "orders.o_clerk"(#2.6)
-                    │                   │   ├── "orders.o_comment"(#2.8)
-                    │                   │   ├── "orders.o_custkey"(#2.1)
-                    │                   │   ├── "orders.o_orderdate"(#2.4)
-                    │                   │   ├── "orders.o_orderkey"(#2.0)
-                    │                   │   ├── "orders.o_orderpriority"(#2.5)
-                    │                   │   ├── "orders.o_orderstatus"(#2.2)
-                    │                   │   ├── "orders.o_shippriority"(#2.7)
-                    │                   │   └── "orders.o_totalprice"(#2.3)
-                    │                   └── (.cardinality): 0.00
+                    │               │   ┌── "orders.o_clerk"(#2.6)
+                    │               │   ├── "orders.o_comment"(#2.8)
+                    │               │   ├── "orders.o_custkey"(#2.1)
+                    │               │   ├── "orders.o_orderdate"(#2.4)
+                    │               │   ├── "orders.o_orderkey"(#2.0)
+                    │               │   ├── "orders.o_orderpriority"(#2.5)
+                    │               │   ├── "orders.o_orderstatus"(#2.2)
+                    │               │   ├── "orders.o_shippriority"(#2.7)
+                    │               │   └── "orders.o_totalprice"(#2.3)
+                    │               └── (.cardinality): 0.00
                     └── Remap { .table_index: 9, (.output_columns): "__scalar_sq_2.avg(customer.c_acctbal)"(#9.0), (.cardinality): 1.00 }
                         └── Project { .table_index: 8, .projections: "__#7.avg(customer.c_acctbal)"(#7.0), (.output_columns): "__#8.avg(customer.c_acctbal)"(#8.0), (.cardinality): 1.00 }
                             └── Aggregate { .key_table_index: 6, .aggregate_table_index: 7, .implementation: None, .exprs: avg("customer.c_acctbal"(#5.5)), .keys: [], (.output_columns): "__#7.avg(customer.c_acctbal)"(#7.0), (.cardinality): 1.00 }

--- a/tests/sqlplannertest/tests/tpch/q4.planner.sql
+++ b/tests/sqlplannertest/tests/tpch/q4.planner.sql
@@ -201,81 +201,103 @@ EnforcerSort
         ├── .keys: "orders.o_orderpriority"(#1.5)
         ├── (.output_columns): [ "__#5.o_orderpriority"(#5.0), "__#6.count(Int64(1))"(#6.0) ]
         ├── (.cardinality): 0.00
-        └── Select
-            ├── .predicate: ("orders.o_orderdate"(#1.4) >= 1993-07-01::date32) AND ("orders.o_orderdate"(#1.4) < 1993-10-01::date32)
+        └── Join
+            ├── .join_type: LeftSemi
+            ├── .implementation: None
+            ├── .join_cond: "orders.o_orderkey"(#1.0) = "__correlated_sq_1.l_orderkey"(#4.0)
             ├── (.output_columns): [ "orders.o_orderdate"(#1.4), "orders.o_orderkey"(#1.0), "orders.o_orderpriority"(#1.5) ]
             ├── (.cardinality): 0.00
-            └── Join
-                ├── .join_type: LeftSemi
-                ├── .implementation: None
-                ├── .join_cond: "orders.o_orderkey"(#1.0) = "__correlated_sq_1.l_orderkey"(#4.0)
-                ├── (.output_columns): [ "orders.o_orderdate"(#1.4), "orders.o_orderkey"(#1.0), "orders.o_orderpriority"(#1.5) ]
+            ├── Select
+            │   ├── .predicate: ("orders.o_orderdate"(#1.4) >= 1993-07-01::date32) AND ("orders.o_orderdate"(#1.4) < 1993-10-01::date32)
+            │   ├── (.output_columns): [ "orders.o_orderdate"(#1.4), "orders.o_orderkey"(#1.0), "orders.o_orderpriority"(#1.5) ]
+            │   ├── (.cardinality): 0.00
+            │   └── Get
+            │       ├── .data_source_id: 7
+            │       ├── .table_index: 1
+            │       ├── .implementation: None
+            │       ├── (.output_columns): [ "orders.o_orderdate"(#1.4), "orders.o_orderkey"(#1.0), "orders.o_orderpriority"(#1.5) ]
+            │       └── (.cardinality): 0.00
+            └── Remap
+                ├── .table_index: 4
+                ├── (.output_columns):
+                │   ┌── "__correlated_sq_1.l_comment"(#4.15)
+                │   ├── "__correlated_sq_1.l_commitdate"(#4.11)
+                │   ├── "__correlated_sq_1.l_discount"(#4.6)
+                │   ├── "__correlated_sq_1.l_extendedprice"(#4.5)
+                │   ├── "__correlated_sq_1.l_linenumber"(#4.3)
+                │   ├── "__correlated_sq_1.l_linestatus"(#4.9)
+                │   ├── "__correlated_sq_1.l_orderkey"(#4.0)
+                │   ├── "__correlated_sq_1.l_partkey"(#4.1)
+                │   ├── "__correlated_sq_1.l_quantity"(#4.4)
+                │   ├── "__correlated_sq_1.l_receiptdate"(#4.12)
+                │   ├── "__correlated_sq_1.l_returnflag"(#4.8)
+                │   ├── "__correlated_sq_1.l_shipdate"(#4.10)
+                │   ├── "__correlated_sq_1.l_shipinstruct"(#4.13)
+                │   ├── "__correlated_sq_1.l_shipmode"(#4.14)
+                │   ├── "__correlated_sq_1.l_suppkey"(#4.2)
+                │   └── "__correlated_sq_1.l_tax"(#4.7)
                 ├── (.cardinality): 0.00
-                ├── Get
-                │   ├── .data_source_id: 7
-                │   ├── .table_index: 1
-                │   ├── .implementation: None
-                │   ├── (.output_columns): [ "orders.o_orderdate"(#1.4), "orders.o_orderkey"(#1.0), "orders.o_orderpriority"(#1.5) ]
-                │   └── (.cardinality): 0.00
-                └── Remap
-                    ├── .table_index: 4
+                └── Project
+                    ├── .table_index: 3
+                    ├── .projections:
+                    │   ┌── "lineitem.l_orderkey"(#2.0)
+                    │   ├── "lineitem.l_partkey"(#2.1)
+                    │   ├── "lineitem.l_suppkey"(#2.2)
+                    │   ├── "lineitem.l_linenumber"(#2.3)
+                    │   ├── "lineitem.l_quantity"(#2.4)
+                    │   ├── "lineitem.l_extendedprice"(#2.5)
+                    │   ├── "lineitem.l_discount"(#2.6)
+                    │   ├── "lineitem.l_tax"(#2.7)
+                    │   ├── "lineitem.l_returnflag"(#2.8)
+                    │   ├── "lineitem.l_linestatus"(#2.9)
+                    │   ├── "lineitem.l_shipdate"(#2.10)
+                    │   ├── "lineitem.l_commitdate"(#2.11)
+                    │   ├── "lineitem.l_receiptdate"(#2.12)
+                    │   ├── "lineitem.l_shipinstruct"(#2.13)
+                    │   ├── "lineitem.l_shipmode"(#2.14)
+                    │   └── "lineitem.l_comment"(#2.15)
                     ├── (.output_columns):
-                    │   ┌── "__correlated_sq_1.l_comment"(#4.15)
-                    │   ├── "__correlated_sq_1.l_commitdate"(#4.11)
-                    │   ├── "__correlated_sq_1.l_discount"(#4.6)
-                    │   ├── "__correlated_sq_1.l_extendedprice"(#4.5)
-                    │   ├── "__correlated_sq_1.l_linenumber"(#4.3)
-                    │   ├── "__correlated_sq_1.l_linestatus"(#4.9)
-                    │   ├── "__correlated_sq_1.l_orderkey"(#4.0)
-                    │   ├── "__correlated_sq_1.l_partkey"(#4.1)
-                    │   ├── "__correlated_sq_1.l_quantity"(#4.4)
-                    │   ├── "__correlated_sq_1.l_receiptdate"(#4.12)
-                    │   ├── "__correlated_sq_1.l_returnflag"(#4.8)
-                    │   ├── "__correlated_sq_1.l_shipdate"(#4.10)
-                    │   ├── "__correlated_sq_1.l_shipinstruct"(#4.13)
-                    │   ├── "__correlated_sq_1.l_shipmode"(#4.14)
-                    │   ├── "__correlated_sq_1.l_suppkey"(#4.2)
-                    │   └── "__correlated_sq_1.l_tax"(#4.7)
+                    │   ┌── "__#3.l_comment"(#3.15)
+                    │   ├── "__#3.l_commitdate"(#3.11)
+                    │   ├── "__#3.l_discount"(#3.6)
+                    │   ├── "__#3.l_extendedprice"(#3.5)
+                    │   ├── "__#3.l_linenumber"(#3.3)
+                    │   ├── "__#3.l_linestatus"(#3.9)
+                    │   ├── "__#3.l_orderkey"(#3.0)
+                    │   ├── "__#3.l_partkey"(#3.1)
+                    │   ├── "__#3.l_quantity"(#3.4)
+                    │   ├── "__#3.l_receiptdate"(#3.12)
+                    │   ├── "__#3.l_returnflag"(#3.8)
+                    │   ├── "__#3.l_shipdate"(#3.10)
+                    │   ├── "__#3.l_shipinstruct"(#3.13)
+                    │   ├── "__#3.l_shipmode"(#3.14)
+                    │   ├── "__#3.l_suppkey"(#3.2)
+                    │   └── "__#3.l_tax"(#3.7)
                     ├── (.cardinality): 0.00
-                    └── Project
-                        ├── .table_index: 3
-                        ├── .projections:
-                        │   ┌── "lineitem.l_orderkey"(#2.0)
-                        │   ├── "lineitem.l_partkey"(#2.1)
-                        │   ├── "lineitem.l_suppkey"(#2.2)
-                        │   ├── "lineitem.l_linenumber"(#2.3)
-                        │   ├── "lineitem.l_quantity"(#2.4)
-                        │   ├── "lineitem.l_extendedprice"(#2.5)
-                        │   ├── "lineitem.l_discount"(#2.6)
-                        │   ├── "lineitem.l_tax"(#2.7)
-                        │   ├── "lineitem.l_returnflag"(#2.8)
-                        │   ├── "lineitem.l_linestatus"(#2.9)
-                        │   ├── "lineitem.l_shipdate"(#2.10)
+                    └── Select
+                        ├── .predicate: "lineitem.l_receiptdate"(#2.12) > "lineitem.l_commitdate"(#2.11)
+                        ├── (.output_columns):
+                        │   ┌── "lineitem.l_comment"(#2.15)
                         │   ├── "lineitem.l_commitdate"(#2.11)
+                        │   ├── "lineitem.l_discount"(#2.6)
+                        │   ├── "lineitem.l_extendedprice"(#2.5)
+                        │   ├── "lineitem.l_linenumber"(#2.3)
+                        │   ├── "lineitem.l_linestatus"(#2.9)
+                        │   ├── "lineitem.l_orderkey"(#2.0)
+                        │   ├── "lineitem.l_partkey"(#2.1)
+                        │   ├── "lineitem.l_quantity"(#2.4)
                         │   ├── "lineitem.l_receiptdate"(#2.12)
+                        │   ├── "lineitem.l_returnflag"(#2.8)
+                        │   ├── "lineitem.l_shipdate"(#2.10)
                         │   ├── "lineitem.l_shipinstruct"(#2.13)
                         │   ├── "lineitem.l_shipmode"(#2.14)
-                        │   └── "lineitem.l_comment"(#2.15)
-                        ├── (.output_columns):
-                        │   ┌── "__#3.l_comment"(#3.15)
-                        │   ├── "__#3.l_commitdate"(#3.11)
-                        │   ├── "__#3.l_discount"(#3.6)
-                        │   ├── "__#3.l_extendedprice"(#3.5)
-                        │   ├── "__#3.l_linenumber"(#3.3)
-                        │   ├── "__#3.l_linestatus"(#3.9)
-                        │   ├── "__#3.l_orderkey"(#3.0)
-                        │   ├── "__#3.l_partkey"(#3.1)
-                        │   ├── "__#3.l_quantity"(#3.4)
-                        │   ├── "__#3.l_receiptdate"(#3.12)
-                        │   ├── "__#3.l_returnflag"(#3.8)
-                        │   ├── "__#3.l_shipdate"(#3.10)
-                        │   ├── "__#3.l_shipinstruct"(#3.13)
-                        │   ├── "__#3.l_shipmode"(#3.14)
-                        │   ├── "__#3.l_suppkey"(#3.2)
-                        │   └── "__#3.l_tax"(#3.7)
+                        │   ├── "lineitem.l_suppkey"(#2.2)
+                        │   └── "lineitem.l_tax"(#2.7)
                         ├── (.cardinality): 0.00
-                        └── Select
-                            ├── .predicate: "lineitem.l_receiptdate"(#2.12) > "lineitem.l_commitdate"(#2.11)
+                        └── Get
+                            ├── .data_source_id: 8
+                            ├── .table_index: 2
+                            ├── .implementation: None
                             ├── (.output_columns):
                             │   ┌── "lineitem.l_comment"(#2.15)
                             │   ├── "lineitem.l_commitdate"(#2.11)
@@ -293,28 +315,6 @@ EnforcerSort
                             │   ├── "lineitem.l_shipmode"(#2.14)
                             │   ├── "lineitem.l_suppkey"(#2.2)
                             │   └── "lineitem.l_tax"(#2.7)
-                            ├── (.cardinality): 0.00
-                            └── Get
-                                ├── .data_source_id: 8
-                                ├── .table_index: 2
-                                ├── .implementation: None
-                                ├── (.output_columns):
-                                │   ┌── "lineitem.l_comment"(#2.15)
-                                │   ├── "lineitem.l_commitdate"(#2.11)
-                                │   ├── "lineitem.l_discount"(#2.6)
-                                │   ├── "lineitem.l_extendedprice"(#2.5)
-                                │   ├── "lineitem.l_linenumber"(#2.3)
-                                │   ├── "lineitem.l_linestatus"(#2.9)
-                                │   ├── "lineitem.l_orderkey"(#2.0)
-                                │   ├── "lineitem.l_partkey"(#2.1)
-                                │   ├── "lineitem.l_quantity"(#2.4)
-                                │   ├── "lineitem.l_receiptdate"(#2.12)
-                                │   ├── "lineitem.l_returnflag"(#2.8)
-                                │   ├── "lineitem.l_shipdate"(#2.10)
-                                │   ├── "lineitem.l_shipinstruct"(#2.13)
-                                │   ├── "lineitem.l_shipmode"(#2.14)
-                                │   ├── "lineitem.l_suppkey"(#2.2)
-                                │   └── "lineitem.l_tax"(#2.7)
-                                └── (.cardinality): 0.00
+                            └── (.cardinality): 0.00
 */
 


### PR DESCRIPTION
## Problem

Predicate pushdown through `LeftSemi` and `LeftAnti` joins was too conservative. The simplification rule kept all filters above these joins, even when a filter only referenced columns from the outer input. Since semi and anti joins only preserve rows from the outer side, those predicates can be safely applied before the join to reduce input size earlier.

## Summary of changes

- Updated `PushSelectThroughJoinRulePass` so predicates above `LeftSemi` and `LeftAnti` joins are pushed into the outer input when they only reference outer-side columns.
- Preserved existing behavior for predicates that cannot be safely pushed, keeping them above the join.
- Added regression coverage for both `LeftSemi` and `LeftAnti` joins to verify outer-only filters are pushed to the outer input and not into the inner side.