### PR TITLE
repository: store query plan in a dedicated table

### DIFF
--- a/optd/repository/api/src/lib.rs
+++ b/optd/repository/api/src/lib.rs
@@ -26,6 +26,7 @@ pub enum RepositoryRequest {
     GetQueryBySql(String),
     GetQueryInstance(i64),
     GetQueryInstances(query::QueryInstanceSelector),
+    GetQueryPlans(i64),
 }
 
 /// Repository API entry point backed by database connection.
@@ -249,6 +250,14 @@ impl<T: ConnectionTrait> Repository<T> {
         selector: query::QueryInstanceSelector,
     ) -> Result<Vec<query::QueryInstanceInfo>, DbErr> {
         query::get_query_instances(&self.db, selector).await
+    }
+
+    /// Returns query plans for a query instance.
+    pub async fn get_query_plans(
+        &self,
+        query_instance_id: i64,
+    ) -> Result<Vec<query::QueryPlanInfo>, DbErr> {
+        query::get_query_plans(&self.db, query_instance_id).await
     }
 }
 
@@ -742,14 +751,49 @@ mod tests {
             .log_query_instance(query::LogQueryInstanceInfo {
                 sql: sql.clone(),
                 snapshot_id: snapshot.snapshot_id,
-                initial_plan: Some(initial_plan.clone()),
-                final_plan: Some(final_plan.clone()),
+                query_plans: vec![
+                    query::LogQueryPlanInfo {
+                        plan: initial_plan.clone(),
+                        description: query::INITIAL_PLAN_DESCRIPTION.to_owned(),
+                    },
+                    query::LogQueryPlanInfo {
+                        plan: final_plan.clone(),
+                        description: query::FINAL_PLAN_DESCRIPTION.to_owned(),
+                    },
+                ],
             })
             .await?;
         let first_instance = repo.get_query_instance(first_instance_id).await?;
         assert_eq!(first_instance.snapshot_id, snapshot.snapshot_id);
-        assert_eq!(first_instance.initial_plan, Some(initial_plan));
-        assert_eq!(first_instance.final_plan, Some(final_plan));
+        assert_eq!(
+            first_instance
+                .query_plans
+                .iter()
+                .map(|query_plan| {
+                    (
+                        query_plan.query_instance_id,
+                        query_plan.description.as_str(),
+                        &query_plan.plan,
+                    )
+                })
+                .collect::<Vec<_>>(),
+            vec![
+                (
+                    first_instance_id,
+                    query::INITIAL_PLAN_DESCRIPTION,
+                    &initial_plan
+                ),
+                (
+                    first_instance_id,
+                    query::FINAL_PLAN_DESCRIPTION,
+                    &final_plan
+                ),
+            ]
+        );
+        assert_eq!(
+            first_instance.query_plans,
+            repo.get_query_plans(first_instance_id).await?
+        );
 
         let query = repo.get_query(first_instance.query_id).await?;
         assert_eq!(query.sql, sql);
@@ -759,13 +803,14 @@ mod tests {
             .log_query_instance(query::LogQueryInstanceInfo {
                 sql: sql.clone(),
                 snapshot_id: snapshot.snapshot_id,
-                initial_plan: None,
-                final_plan: None,
+                query_plans: Vec::new(),
             })
             .await?;
         let second_instance = repo.get_query_instance(second_instance_id).await?;
         assert_eq!(second_instance.query_id, first_instance.query_id);
         assert_ne!(second_instance.id, first_instance.id);
+        assert!(second_instance.query_plans.is_empty());
+        assert!(repo.get_query_plans(second_instance_id).await?.is_empty());
         assert_eq!(
             repo.get_query_instances(query::QueryInstanceSelector::QueryId(query.query_id))
                 .await?
@@ -787,8 +832,7 @@ mod tests {
             .log_query_instance(query::LogQueryInstanceInfo {
                 sql: "SELECT * FROM t WHERE id = 1".to_owned(),
                 snapshot_id: snapshot.snapshot_id,
-                initial_plan: None,
-                final_plan: None,
+                query_plans: Vec::new(),
             })
             .await?;
         let different_sql_instance = repo.get_query_instance(different_sql_instance_id).await?;

--- a/optd/repository/api/src/optd_catalog.rs
+++ b/optd/repository/api/src/optd_catalog.rs
@@ -11,7 +11,10 @@ use sea_orm::DatabaseConnection;
 use crate::{
     Repository,
     entity::column::ColumnType,
-    query::{LogQueryInstanceInfo, QueryPlan},
+    query::{
+        FINAL_PLAN_DESCRIPTION, INITIAL_PLAN_DESCRIPTION, LogQueryInstanceInfo, LogQueryPlanInfo,
+        QueryPlan,
+    },
     schema::{CreateSchemaInfo, SchemaInfo},
     stats::UpdateTableStatsInfo,
     table::{CreateColumnInfo, CreateTableInfo, GetTableInfo, TableInfo},
@@ -180,11 +183,24 @@ impl RepositoryCatalog {
     ) -> Result<i64, sea_orm::DbErr> {
         let repo = Repository::new(self.db.clone());
         let snapshot_id = repo.reader().await?.snapshot().snapshot_id;
+        let mut query_plans = Vec::new();
+        if let Some(initial_plan) = initial_plan {
+            query_plans.push(LogQueryPlanInfo {
+                plan: initial_plan,
+                description: INITIAL_PLAN_DESCRIPTION.to_owned(),
+            });
+        }
+        if let Some(final_plan) = final_plan {
+            query_plans.push(LogQueryPlanInfo {
+                plan: final_plan,
+                description: FINAL_PLAN_DESCRIPTION.to_owned(),
+            });
+        }
+
         repo.log_query_instance(LogQueryInstanceInfo {
             sql,
             snapshot_id,
-            initial_plan,
-            final_plan,
+            query_plans,
         })
         .await
     }
@@ -410,10 +426,30 @@ mod tests {
         let query = runtime.block_on(repo.get_query(instance.query_id))?;
         assert_eq!(query.sql, "SELECT 1");
         assert_eq!(
-            instance.initial_plan,
-            Some(Json::String("initial".to_owned()))
+            instance
+                .query_plans
+                .into_iter()
+                .map(|query_plan| {
+                    (
+                        query_plan.query_instance_id,
+                        query_plan.description,
+                        query_plan.plan,
+                    )
+                })
+                .collect::<Vec<_>>(),
+            vec![
+                (
+                    instance_id,
+                    crate::query::INITIAL_PLAN_DESCRIPTION.to_owned(),
+                    Json::String("initial".to_owned())
+                ),
+                (
+                    instance_id,
+                    crate::query::FINAL_PLAN_DESCRIPTION.to_owned(),
+                    Json::String("final".to_owned())
+                ),
+            ]
         );
-        assert_eq!(instance.final_plan, Some(Json::String("final".to_owned())));
 
         Ok(())
     }

--- a/optd/repository/api/src/query/get_query_instance.rs
+++ b/optd/repository/api/src/query/get_query_instance.rs
@@ -2,15 +2,20 @@ use sea_orm::{ConnectionTrait, DbErr, EntityTrait};
 
 use crate::entity::prelude::QueryInstance;
 
-use super::QueryInstanceInfo;
+use super::{QueryInstanceInfo, get_query_plans, query_instance_info_from_parts};
 
 /// Returns a query instance by id.
 pub async fn get_query_instance<C>(db: &C, id: i64) -> Result<Option<QueryInstanceInfo>, DbErr>
 where
     C: ConnectionTrait,
 {
-    QueryInstance::find_by_id(id)
-        .one(db)
-        .await
-        .map(|query_instance| query_instance.map(QueryInstanceInfo::from))
+    let Some(query_instance) = QueryInstance::find_by_id(id).one(db).await? else {
+        return Ok(None);
+    };
+    let query_plans = get_query_plans(db, id).await?;
+
+    Ok(Some(query_instance_info_from_parts(
+        query_instance,
+        query_plans,
+    )))
 }

--- a/optd/repository/api/src/query/get_query_instances.rs
+++ b/optd/repository/api/src/query/get_query_instances.rs
@@ -2,7 +2,10 @@ use sea_orm::{ColumnTrait, ConnectionTrait, DbErr, EntityTrait, QueryFilter, Que
 
 use crate::entity::{prelude::QueryInstance, query_instance};
 
-use super::{QueryInstanceInfo, QueryInstanceSelector, get_query_by_sql};
+use super::{
+    QueryInstanceInfo, QueryInstanceSelector, get_query_by_sql, get_query_plans,
+    query_instance_info_from_parts,
+};
 
 /// Returns query instances matching `selector`.
 pub async fn get_query_instances<C>(
@@ -22,15 +25,17 @@ where
         }
     };
 
-    QueryInstance::find()
+    let query_instances = QueryInstance::find()
         .filter(query_instance::Column::QueryId.eq(query_id))
         .order_by_asc(query_instance::Column::Id)
         .all(db)
-        .await
-        .map(|query_instances| {
-            query_instances
-                .into_iter()
-                .map(QueryInstanceInfo::from)
-                .collect()
-        })
+        .await?;
+
+    let mut infos = Vec::with_capacity(query_instances.len());
+    for query_instance in query_instances {
+        let query_plans = get_query_plans(db, query_instance.id).await?;
+        infos.push(query_instance_info_from_parts(query_instance, query_plans));
+    }
+
+    Ok(infos)
 }

--- a/optd/repository/api/src/query/get_query_instances.rs
+++ b/optd/repository/api/src/query/get_query_instances.rs
@@ -1,11 +1,11 @@
 use sea_orm::{ColumnTrait, ConnectionTrait, DbErr, EntityTrait, QueryFilter, QueryOrder};
 
-use crate::entity::{prelude::QueryInstance, query_instance};
-
-use super::{
-    QueryInstanceInfo, QueryInstanceSelector, get_query_by_sql, get_query_plans,
-    query_instance_info_from_parts,
+use crate::entity::{
+    prelude::{QueryInstance, QueryPlan as QueryPlanEntity},
+    query_instance, query_plan,
 };
+
+use super::{QueryInstanceInfo, QueryInstanceSelector, QueryPlanInfo, get_query_by_sql};
 
 /// Returns query instances matching `selector`.
 pub async fn get_query_instances<C>(
@@ -25,17 +25,23 @@ where
         }
     };
 
-    let query_instances = QueryInstance::find()
+    QueryInstance::find()
         .filter(query_instance::Column::QueryId.eq(query_id))
         .order_by_asc(query_instance::Column::Id)
+        .find_with_related(QueryPlanEntity)
+        .order_by_asc(query_plan::Column::Id)
         .all(db)
-        .await?;
-
-    let mut infos = Vec::with_capacity(query_instances.len());
-    for query_instance in query_instances {
-        let query_plans = get_query_plans(db, query_instance.id).await?;
-        infos.push(query_instance_info_from_parts(query_instance, query_plans));
-    }
-
-    Ok(infos)
+        .await
+        .map(|query_instances| {
+            query_instances
+                .into_iter()
+                .map(|(query_instance, query_plans)| QueryInstanceInfo {
+                    id: query_instance.id,
+                    query_id: query_instance.query_id,
+                    snapshot_id: query_instance.snapshot_id,
+                    query_time: query_instance.query_time,
+                    query_plans: query_plans.into_iter().map(QueryPlanInfo::from).collect(),
+                })
+                .collect()
+        })
 }

--- a/optd/repository/api/src/query/get_query_plans.rs
+++ b/optd/repository/api/src/query/get_query_plans.rs
@@ -1,0 +1,18 @@
+use sea_orm::{ColumnTrait, ConnectionTrait, DbErr, EntityTrait, QueryFilter, QueryOrder};
+
+use crate::entity::{prelude::QueryPlan, query_plan};
+
+use super::QueryPlanInfo;
+
+/// Returns query plans for a query instance.
+pub async fn get_query_plans<C>(db: &C, query_instance_id: i64) -> Result<Vec<QueryPlanInfo>, DbErr>
+where
+    C: ConnectionTrait,
+{
+    QueryPlan::find()
+        .filter(query_plan::Column::QueryInstanceId.eq(query_instance_id))
+        .order_by_asc(query_plan::Column::Id)
+        .all(db)
+        .await
+        .map(|query_plans| query_plans.into_iter().map(QueryPlanInfo::from).collect())
+}

--- a/optd/repository/api/src/query/log_query_instance.rs
+++ b/optd/repository/api/src/query/log_query_instance.rs
@@ -1,6 +1,9 @@
 use sea_orm::{ActiveValue::Set, ConnectionTrait, DbErr, EntityTrait};
 
-use crate::entity::{prelude::QueryInstance, query_instance};
+use crate::entity::{
+    prelude::{QueryInstance, QueryPlan as QueryPlanEntity},
+    query_instance, query_plan,
+};
 
 use super::{LogQueryInstanceInfo, get_or_create_query_id};
 
@@ -13,12 +16,24 @@ where
     let result = QueryInstance::insert(query_instance::ActiveModel {
         query_id: Set(query_id),
         snapshot_id: Set(info.snapshot_id),
-        initial_plan: Set(info.initial_plan),
-        final_plan: Set(info.final_plan),
         ..Default::default()
     })
     .exec(db)
     .await?;
 
-    Ok(result.last_insert_id)
+    let query_instance_id = result.last_insert_id;
+    if !info.query_plans.is_empty() {
+        QueryPlanEntity::insert_many(info.query_plans.into_iter().map(|query_plan| {
+            query_plan::ActiveModel {
+                query_instance_id: Set(query_instance_id),
+                plan: Set(query_plan.plan),
+                description: Set(query_plan.description),
+                ..Default::default()
+            }
+        }))
+        .exec(db)
+        .await?;
+    }
+
+    Ok(query_instance_id)
 }

--- a/optd/repository/api/src/query/mod.rs
+++ b/optd/repository/api/src/query/mod.rs
@@ -3,22 +3,36 @@ mod get_query;
 mod get_query_by_sql;
 mod get_query_instance;
 mod get_query_instances;
+mod get_query_plans;
 mod log_query_instance;
 
 use chrono::{DateTime, Utc};
 use sea_orm::prelude::Json;
 
-use crate::entity::{query, query_instance};
+use crate::entity::{query, query_instance, query_plan};
 
 pub use get_or_create_query_id::*;
 pub use get_query::*;
 pub use get_query_by_sql::*;
 pub use get_query_instance::*;
 pub use get_query_instances::*;
+pub use get_query_plans::*;
 pub use log_query_instance::*;
 
 /// JSON-encoded query plan payload.
 pub type QueryPlan = Json;
+
+pub const INITIAL_PLAN_DESCRIPTION: &str = "initial-plan";
+pub const FINAL_PLAN_DESCRIPTION: &str = "final-plan";
+
+/// Information needed to log a query plan.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LogQueryPlanInfo {
+    /// JSON-encoded plan payload.
+    pub plan: QueryPlan,
+    /// Description of this plan.
+    pub description: String,
+}
 
 /// Information needed to log a query instance.
 #[derive(Debug, Clone, PartialEq)]
@@ -27,10 +41,8 @@ pub struct LogQueryInstanceInfo {
     pub sql: String,
     /// Snapshot id the query instance runs against.
     pub snapshot_id: i64,
-    /// Initial query plan, if recorded.
-    pub initial_plan: Option<QueryPlan>,
-    /// Final query plan, if recorded.
-    pub final_plan: Option<QueryPlan>,
+    /// Query plans recorded for this instance.
+    pub query_plans: Vec<LogQueryPlanInfo>,
 }
 
 /// Query instance lookup selector.
@@ -62,10 +74,21 @@ pub struct QueryInstanceInfo {
     pub snapshot_id: i64,
     /// Time at which the query instance was created.
     pub query_time: DateTime<Utc>,
-    /// Initial query plan, if recorded.
-    pub initial_plan: Option<QueryPlan>,
-    /// Final query plan, if recorded.
-    pub final_plan: Option<QueryPlan>,
+    /// Query plans recorded for this instance.
+    pub query_plans: Vec<QueryPlanInfo>,
+}
+
+/// Stored query plan metadata.
+#[derive(Debug, Clone, PartialEq)]
+pub struct QueryPlanInfo {
+    /// Numeric query plan id.
+    pub id: i64,
+    /// Query instance this plan belongs to.
+    pub query_instance_id: i64,
+    /// JSON-encoded plan payload.
+    pub plan: QueryPlan,
+    /// Description of this plan.
+    pub description: String,
 }
 
 impl From<query::Model> for QueryInfo {
@@ -77,15 +100,26 @@ impl From<query::Model> for QueryInfo {
     }
 }
 
-impl From<query_instance::Model> for QueryInstanceInfo {
-    fn from(query_instance: query_instance::Model) -> Self {
+impl From<query_plan::Model> for QueryPlanInfo {
+    fn from(query_plan: query_plan::Model) -> Self {
         Self {
-            id: query_instance.id,
-            query_id: query_instance.query_id,
-            snapshot_id: query_instance.snapshot_id,
-            query_time: query_instance.query_time,
-            initial_plan: query_instance.initial_plan,
-            final_plan: query_instance.final_plan,
+            id: query_plan.id,
+            query_instance_id: query_plan.query_instance_id,
+            plan: query_plan.plan,
+            description: query_plan.description,
         }
+    }
+}
+
+fn query_instance_info_from_parts(
+    query_instance: query_instance::Model,
+    query_plans: Vec<QueryPlanInfo>,
+) -> QueryInstanceInfo {
+    QueryInstanceInfo {
+        id: query_instance.id,
+        query_id: query_instance.query_id,
+        snapshot_id: query_instance.snapshot_id,
+        query_time: query_instance.query_time,
+        query_plans,
     }
 }

--- a/optd/repository/entity/src/lib.rs
+++ b/optd/repository/entity/src/lib.rs
@@ -3,6 +3,7 @@ pub mod prelude;
 pub mod column;
 pub mod query;
 pub mod query_instance;
+pub mod query_plan;
 pub mod schema;
 pub mod snapshot;
 pub mod snapshot_changes;

--- a/optd/repository/entity/src/prelude.rs
+++ b/optd/repository/entity/src/prelude.rs
@@ -1,6 +1,7 @@
 pub use super::column::Entity as Column;
 pub use super::query::Entity as Query;
 pub use super::query_instance::Entity as QueryInstance;
+pub use super::query_plan::Entity as QueryPlan;
 pub use super::schema::Entity as Schema;
 pub use super::snapshot::Entity as Snapshot;
 pub use super::snapshot_changes::Entity as SnapshotChanges;

--- a/optd/repository/entity/src/query.rs
+++ b/optd/repository/entity/src/query.rs
@@ -12,6 +12,9 @@ pub struct Model {
 
     /// The SQL text for this query.
     pub sql: String,
+
+    #[sea_orm(has_many)]
+    pub query_instances: HasMany<super::query_instance::Entity>,
 }
 
 impl ActiveModelBehavior for ActiveModel {}

--- a/optd/repository/entity/src/query_instance.rs
+++ b/optd/repository/entity/src/query_instance.rs
@@ -4,7 +4,7 @@ use sea_orm::{
 };
 
 /// The query instance table stores information about each query instance,
-/// including the query itself, the snapshot it is running against, and the initial/final plans.
+/// including the query itself and the snapshot it is running against.
 /// This table is not in the DuckLake schema.
 #[sea_orm::model]
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
@@ -22,12 +22,6 @@ pub struct Model {
     /// The timestamp at which this query instance was created.
     #[sea_orm(default_expr = "Expr::current_timestamp()")]
     pub query_time: chrono::DateTime<Utc>,
-
-    /// The initial plan for the query instance, encoded as JSON.
-    pub initial_plan: Option<Json>,
-
-    /// The final plan for the query instance, encoded as JSON.
-    pub final_plan: Option<Json>,
 
     #[sea_orm(belongs_to, from = "query_id", to = "query_id")]
     pub query: HasOne<super::query::Entity>,

--- a/optd/repository/entity/src/query_instance.rs
+++ b/optd/repository/entity/src/query_instance.rs
@@ -25,6 +25,9 @@ pub struct Model {
 
     #[sea_orm(belongs_to, from = "query_id", to = "query_id")]
     pub query: HasOne<super::query::Entity>,
+
+    #[sea_orm(has_many)]
+    pub query_plans: HasMany<super::query_plan::Entity>,
 }
 
 impl ActiveModelBehavior for ActiveModel {}

--- a/optd/repository/entity/src/query_plan.rs
+++ b/optd/repository/entity/src/query_plan.rs
@@ -1,0 +1,25 @@
+use sea_orm::entity::prelude::*;
+
+/// The query plan table stores JSON-encoded plans associated with query instances.
+/// This table is not in the DuckLake schema.
+#[sea_orm::model]
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "optd_query_plan")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i64,
+
+    /// Refers to an `id` from the `optd_query_instance` table.
+    pub query_instance_id: i64,
+
+    /// The query plan, encoded as JSON.
+    pub plan: Json,
+
+    /// Description of this plan, such as `initial_plan` or `final_plan`.
+    pub description: String,
+
+    #[sea_orm(belongs_to, from = "query_instance_id", to = "id")]
+    pub query_instance: HasOne<super::query_instance::Entity>,
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/optd/repository/migration/src/m20260331_150556_create_initial_tables.rs
+++ b/optd/repository/migration/src/m20260331_150556_create_initial_tables.rs
@@ -94,6 +94,14 @@ impl MigrationTrait for Migration {
                     .to_owned(),
             )
             .await?;
+        manager
+            .create_table(
+                schema
+                    .create_table_from_entity(optd_repository_entity::query_plan::Entity)
+                    .if_not_exists()
+                    .to_owned(),
+            )
+            .await?;
 
         optd_repository_entity::prelude::Snapshot::insert(
             optd_repository_entity::snapshot::ActiveModel {
@@ -110,6 +118,14 @@ impl MigrationTrait for Migration {
     }
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(
+                Table::drop()
+                    .table(optd_repository_entity::query_plan::Entity)
+                    .if_exists()
+                    .to_owned(),
+            )
+            .await?;
         manager
             .drop_table(
                 Table::drop()


### PR DESCRIPTION
## Problem

Query plans were stored directly on `optd_query_instance` as `initial_plan` and `final_plan`, which made the schema too rigid for recording plans generated by different passes for the same query execution. The repository API also needed to expose query plans as first-class records associated with a query instance.

## Summary of changes

- Added a new `optd_query_plan` entity/table with `id`, `query_instance_id`, `plan`, and `description`.
- Removed `initial_plan` and `final_plan` from `optd_query_instance`.
- Updated query logging to write query plan rows into `optd_query_plan`, using bulk insert for multiple plans.
- Changed `LogQueryInstanceInfo` to accept `query_plans: Vec<LogQueryPlanInfo>`.
- Changed `QueryInstanceInfo` to return `query_plans: Vec<QueryPlanInfo>`.
- Added `Repository::get_query_plans` for reading plans by query instance.
- Added SeaORM relationships:
  - `query -> query_instances`
  - `query_instance -> query_plans`
  - `query_plan -> query_instance`
- Updated `get_query_instances` to eager-load plans through the `query_instance -> query_plan` relationship.
- Kept the catalog convenience API accepting initial/final plans, mapping them into query plan rows with descriptions.
- Updated tests to validate query plan rows and vector-based query instance reads.