### PR TITLE
fix optd-datafusion column binding when reconstructing datafusion plan

### DIFF
--- a/connectors/datafusion/src/planner/from_optd.rs
+++ b/connectors/datafusion/src/planner/from_optd.rs
@@ -199,16 +199,16 @@ impl OptdQueryPlannerContext<'_> {
         let keys = node.keys().borrow::<List>();
         let exprs = node.exprs().borrow::<List>();
         let scope = self.visible_column_scope(node.input())?;
-        let (group_expr, aggr_expr) = self.with_visible_column_scope(scope, |this| {
+        let (group_expr, aggr_expr) = self.with_visible_column_scope(scope, |ctx| {
             let group_expr = keys
                 .members()
                 .iter()
-                .map(|e| this.try_from_optd_scalar_expr(e))
+                .map(|e| ctx.try_from_optd_scalar_expr(e))
                 .try_collect()?;
             let aggr_expr = exprs
                 .members()
                 .iter()
-                .map(|e| this.try_from_optd_scalar_expr(e))
+                .map(|e| ctx.try_from_optd_scalar_expr(e))
                 .try_collect()?;
             Ok((group_expr, aggr_expr))
         })?;
@@ -237,11 +237,11 @@ impl OptdQueryPlannerContext<'_> {
         let input = self.try_from_optd_plan(node.input())?;
         let projection_list = node.projections().borrow::<List>();
         let scope = self.visible_column_scope(node.input())?;
-        let exprs = self.with_visible_column_scope(scope, |this| {
+        let exprs = self.with_visible_column_scope(scope, |ctx| {
             projection_list
                 .members()
                 .iter()
-                .map(|e| this.try_from_optd_scalar_expr(e))
+                .map(|e| ctx.try_from_optd_scalar_expr(e))
                 .try_collect()
         })?;
 
@@ -258,19 +258,19 @@ impl OptdQueryPlannerContext<'_> {
 
         let mut scope = self.visible_column_scope(node.outer())?;
         scope.extend(self.visible_column_scope(node.inner())?);
-        let (on, filter): (_, Vec<_>) = self.with_visible_column_scope(scope, |this| {
+        let (on, filter): (_, Vec<_>) = self.with_visible_column_scope(scope, |ctx| {
             let on = equi_conds
                 .iter()
                 .map(|(l, r)| {
                     Ok((
-                        DFExpr::Column(this.try_from_optd_column(l)?),
-                        DFExpr::Column(this.try_from_optd_column(r)?),
+                        DFExpr::Column(ctx.try_from_optd_column(l)?),
+                        DFExpr::Column(ctx.try_from_optd_column(r)?),
                     ))
                 })
                 .try_collect()?;
             let filter = non_equi_conds
                 .iter()
-                .map(|e| this.try_from_optd_scalar_expr(e))
+                .map(|e| ctx.try_from_optd_scalar_expr(e))
                 .try_collect()?;
             Ok((on, filter))
         })?;
@@ -305,8 +305,8 @@ impl OptdQueryPlannerContext<'_> {
     pub fn try_from_optd_select(&mut self, node: SelectBorrowed<'_>) -> Result<DFLogicalPlan> {
         let input = self.try_from_optd_plan(node.input())?;
         let scope = self.visible_column_scope(node.input())?;
-        let predicate = self.with_visible_column_scope(scope, |this| {
-            this.try_from_optd_scalar_expr(node.predicate())
+        let predicate = self.with_visible_column_scope(scope, |ctx| {
+            ctx.try_from_optd_scalar_expr(node.predicate())
         })?;
         let filter =
             logical_plan::Filter::try_new(predicate, Arc::new(input)).context(DataFusionSnafu)?;
@@ -342,11 +342,11 @@ impl OptdQueryPlannerContext<'_> {
     ) -> Result<DFLogicalPlan> {
         let input = self.try_from_optd_plan(node.input())?;
         let scope = self.visible_column_scope(node.input())?;
-        let expr = self.with_visible_column_scope(scope, |this| {
+        let expr = self.with_visible_column_scope(scope, |ctx| {
             node.tuple_ordering()
                 .iter()
                 .map(|(column, direction)| {
-                    let expr = DFExpr::Column(this.try_from_optd_column(column)?);
+                    let expr = DFExpr::Column(ctx.try_from_optd_column(column)?);
                     let asc = matches!(direction, TupleOrderingDirection::Asc);
                     Ok(logical_expr::expr::Sort::new(expr, asc, !asc))
                 })

--- a/connectors/datafusion/src/planner/from_optd.rs
+++ b/connectors/datafusion/src/planner/from_optd.rs
@@ -228,27 +228,23 @@ impl OptdQueryPlannerContext<'_> {
         .output_schema(&self.inner)
         .context(OptdSnafu)?;
 
-        let input = self.try_from_optd_plan(node.input())?;
+        let input = self.try_from_optd_plan_with_outputs(node.input())?;
 
         let keys = node.keys().borrow::<List>();
         let exprs = node.exprs().borrow::<List>();
-        let scope = self.visible_column_scope(node.input())?;
-        let (group_expr, aggr_expr) = self.with_visible_column_scope(scope, |ctx| {
-            let group_expr = keys
-                .members()
-                .iter()
-                .map(|e| ctx.try_from_optd_scalar_expr(e))
-                .try_collect()?;
-            let aggr_expr = exprs
-                .members()
-                .iter()
-                .map(|e| ctx.try_from_optd_scalar_expr(e))
-                .try_collect()?;
-            Ok((group_expr, aggr_expr))
-        })?;
+        let group_expr = keys
+            .members()
+            .iter()
+            .map(|e| self.try_from_optd_scalar_expr_with_env(e, &input.outputs))
+            .try_collect()?;
+        let aggr_expr = exprs
+            .members()
+            .iter()
+            .map(|e| self.try_from_optd_scalar_expr_with_env(e, &input.outputs))
+            .try_collect()?;
 
         let aggregate =
-            self.try_new_df_aggregate(&output_schema, Arc::new(input), group_expr, aggr_expr)?;
+            self.try_new_df_aggregate(&output_schema, Arc::new(input.plan), group_expr, aggr_expr)?;
         Ok(DFLogicalPlan::Aggregate(aggregate))
     }
     pub fn try_from_optd_remap(&mut self, node: RemapBorrowed<'_>) -> Result<DFLogicalPlan> {
@@ -268,18 +264,16 @@ impl OptdQueryPlannerContext<'_> {
     }
 
     pub fn try_from_optd_project(&mut self, node: ProjectBorrowed<'_>) -> Result<DFLogicalPlan> {
-        let input = self.try_from_optd_plan(node.input())?;
+        let input = self.try_from_optd_plan_with_outputs(node.input())?;
         let projection_list = node.projections().borrow::<List>();
-        let scope = self.visible_column_scope(node.input())?;
-        let exprs = self.with_visible_column_scope(scope, |ctx| {
-            projection_list
-                .members()
-                .iter()
-                .map(|e| ctx.try_from_optd_scalar_expr(e))
-                .try_collect()
-        })?;
+        let exprs = projection_list
+            .members()
+            .iter()
+            .map(|e| self.try_from_optd_scalar_expr_with_env(e, &input.outputs))
+            .try_collect()?;
 
-        let projection = self.try_new_df_projection(node.table_index(), exprs, Arc::new(input))?;
+        let projection =
+            self.try_new_df_projection(node.table_index(), exprs, Arc::new(input.plan))?;
 
         Ok(DFLogicalPlan::Projection(projection))
     }
@@ -337,20 +331,17 @@ impl OptdQueryPlannerContext<'_> {
     }
 
     pub fn try_from_optd_select(&mut self, node: SelectBorrowed<'_>) -> Result<DFLogicalPlan> {
-        let input = self.try_from_optd_plan(node.input())?;
-        let scope = self.visible_column_scope(node.input())?;
-        let predicate = self.with_visible_column_scope(scope, |ctx| {
-            ctx.try_from_optd_scalar_expr(node.predicate())
-        })?;
+        let input = self.try_from_optd_plan_with_outputs(node.input())?;
+        let predicate = self.try_from_optd_scalar_expr_with_env(node.predicate(), &input.outputs)?;
         let filter =
-            logical_plan::Filter::try_new(predicate, Arc::new(input)).context(DataFusionSnafu)?;
+            logical_plan::Filter::try_new(predicate, Arc::new(input.plan)).context(DataFusionSnafu)?;
         Ok(DFLogicalPlan::Filter(filter))
     }
 
     pub fn try_from_optd_limit(&mut self, node: LimitBorrowed<'_>) -> Result<DFLogicalPlan> {
-        let input = self.try_from_optd_plan(node.input())?;
-        let skip_expr = self.try_from_optd_scalar_expr(node.skip())?;
-        let fetch_expr = self.try_from_optd_scalar_expr(node.fetch())?;
+        let input = self.try_from_optd_plan_with_outputs(node.input())?;
+        let skip_expr = self.try_from_optd_scalar_expr_with_env(node.skip(), &input.outputs)?;
+        let fetch_expr = self.try_from_optd_scalar_expr_with_env(node.fetch(), &input.outputs)?;
 
         let skip = match skip_expr {
             DFExpr::Literal(datafusion::scalar::ScalarValue::Int64(Some(0)), _) => None,
@@ -366,7 +357,7 @@ impl OptdQueryPlannerContext<'_> {
         Ok(DFLogicalPlan::Limit(logical_plan::Limit {
             skip,
             fetch,
-            input: Arc::new(input),
+            input: Arc::new(input.plan),
         }))
     }
 
@@ -374,22 +365,20 @@ impl OptdQueryPlannerContext<'_> {
         &mut self,
         node: EnforcerSortBorrowed<'_>,
     ) -> Result<DFLogicalPlan> {
-        let input = self.try_from_optd_plan(node.input())?;
-        let scope = self.visible_column_scope(node.input())?;
-        let expr = self.with_visible_column_scope(scope, |ctx| {
-            node.tuple_ordering()
-                .iter()
-                .map(|(column, direction)| {
-                    let expr = DFExpr::Column(ctx.try_from_optd_column(column)?);
-                    let asc = matches!(direction, TupleOrderingDirection::Asc);
-                    Ok(logical_expr::expr::Sort::new(expr, asc, !asc))
-                })
-                .try_collect()
-        })?;
+        let input = self.try_from_optd_plan_with_outputs(node.input())?;
+        let expr = node
+            .tuple_ordering()
+            .iter()
+            .map(|(column, direction)| {
+                let expr = DFExpr::Column(self.try_from_optd_column_in_env(column, &input.outputs)?);
+                let asc = matches!(direction, TupleOrderingDirection::Asc);
+                Ok(logical_expr::expr::Sort::new(expr, asc, !asc))
+            })
+            .try_collect()?;
 
         Ok(DFLogicalPlan::Sort(logical_plan::Sort {
             expr,
-            input: Arc::new(input),
+            input: Arc::new(input.plan),
             fetch: None,
         }))
     }
@@ -1089,6 +1078,15 @@ mod tests {
 
 impl OptdQueryPlannerContext<'_> {
     pub fn try_from_optd_scalar_expr(&mut self, expr: &Scalar) -> Result<DFExpr> {
+        let output_env = OutputEnv::default();
+        self.try_from_optd_scalar_expr_with_env(expr, &output_env)
+    }
+
+    fn try_from_optd_scalar_expr_with_env(
+        &mut self,
+        expr: &Scalar,
+        output_env: &OutputEnv,
+    ) -> Result<DFExpr> {
         match &expr.kind {
             optd_core::ir::ScalarKind::Literal(meta) => {
                 let node = Literal::borrow_raw_parts(meta, &expr.common);
@@ -1096,46 +1094,46 @@ impl OptdQueryPlannerContext<'_> {
             }
             optd_core::ir::ScalarKind::ColumnRef(meta) => {
                 let node = ColumnRef::borrow_raw_parts(meta, &expr.common);
-                self.try_from_optd_column_ref(node)
+                self.try_from_optd_column_ref(node, output_env)
             }
             optd_core::ir::ScalarKind::BinaryOp(meta) => {
                 let node = BinaryOp::borrow_raw_parts(meta, &expr.common);
-                self.try_from_optd_binary_op(node)
+                self.try_from_optd_binary_op(node, output_env)
             }
             optd_core::ir::ScalarKind::NaryOp(meta) => {
                 let node = NaryOp::borrow_raw_parts(meta, &expr.common);
-                self.try_from_optd_nary_op(node)
+                self.try_from_optd_nary_op(node, output_env)
             }
             optd_core::ir::ScalarKind::List(_) => {
                 whatever!("expr list should not be extracted from this path")
             }
             optd_core::ir::ScalarKind::Function(meta) => {
                 let node = Function::borrow_raw_parts(meta, &expr.common);
-                self.try_from_optd_function(node)
+                self.try_from_optd_function(node, output_env)
             }
             optd_core::ir::ScalarKind::Cast(meta) => {
                 let node = Cast::borrow_raw_parts(meta, &expr.common);
-                self.try_from_optd_cast(node)
+                self.try_from_optd_cast(node, output_env)
             }
             optd_core::ir::ScalarKind::IsNull(meta) => {
                 let node = IsNull::borrow_raw_parts(meta, &expr.common);
-                self.try_from_optd_is_null(node)
+                self.try_from_optd_is_null(node, output_env)
             }
             optd_core::ir::ScalarKind::IsNotNull(meta) => {
                 let node = IsNotNull::borrow_raw_parts(meta, &expr.common);
-                self.try_from_optd_is_not_null(node)
+                self.try_from_optd_is_not_null(node, output_env)
             }
             optd_core::ir::ScalarKind::Like(meta) => {
                 let node = Like::borrow_raw_parts(meta, &expr.common);
-                self.try_from_optd_like(node)
+                self.try_from_optd_like(node, output_env)
             }
             optd_core::ir::ScalarKind::Case(meta) => {
                 let node = Case::borrow_raw_parts(meta, &expr.common);
-                self.try_from_optd_case(node)
+                self.try_from_optd_case(node, output_env)
             }
             optd_core::ir::ScalarKind::InList(meta) => {
                 let node = InList::borrow_raw_parts(meta, &expr.common);
-                self.try_from_optd_in_list(node)
+                self.try_from_optd_in_list(node, output_env)
             }
         }
     }
@@ -1145,14 +1143,22 @@ impl OptdQueryPlannerContext<'_> {
         Ok(DFExpr::Literal(value, None))
     }
 
-    pub fn try_from_optd_column_ref(&self, node: ColumnRefBorrowed<'_>) -> Result<DFExpr> {
-        let column = self.try_from_optd_column(node.column())?;
+    pub fn try_from_optd_column_ref(
+        &self,
+        node: ColumnRefBorrowed<'_>,
+        output_env: &OutputEnv,
+    ) -> Result<DFExpr> {
+        let column = self.try_from_optd_column_in_env(node.column(), output_env)?;
         Ok(DFExpr::Column(column))
     }
 
-    pub fn try_from_optd_binary_op(&mut self, node: BinaryOpBorrowed<'_>) -> Result<DFExpr> {
-        let left = self.try_from_optd_scalar_expr(node.lhs())?;
-        let right = self.try_from_optd_scalar_expr(node.rhs())?;
+    pub fn try_from_optd_binary_op(
+        &mut self,
+        node: BinaryOpBorrowed<'_>,
+        output_env: &OutputEnv,
+    ) -> Result<DFExpr> {
+        let left = self.try_from_optd_scalar_expr_with_env(node.lhs(), output_env)?;
+        let right = self.try_from_optd_scalar_expr_with_env(node.rhs(), output_env)?;
         let op = match node.op_kind() {
             BinaryOpKind::Plus => logical_expr::Operator::Plus,
             BinaryOpKind::Minus => logical_expr::Operator::Minus,
@@ -1199,7 +1205,11 @@ impl OptdQueryPlannerContext<'_> {
         Ok(logical_expr::binary_expr(left, op, right))
     }
 
-    pub fn try_from_optd_nary_op(&mut self, node: NaryOpBorrowed<'_>) -> Result<DFExpr> {
+    pub fn try_from_optd_nary_op(
+        &mut self,
+        node: NaryOpBorrowed<'_>,
+        output_env: &OutputEnv,
+    ) -> Result<DFExpr> {
         let op = match node.op_kind() {
             NaryOpKind::And => logical_expr::Operator::And,
             NaryOpKind::Or => logical_expr::Operator::Or,
@@ -1208,7 +1218,7 @@ impl OptdQueryPlannerContext<'_> {
         let exprs: Vec<_> = node
             .terms()
             .iter()
-            .map(|term| self.try_from_optd_scalar_expr(term))
+            .map(|term| self.try_from_optd_scalar_expr_with_env(term, output_env))
             .try_collect()?;
 
         let nary_expr = exprs
@@ -1219,25 +1229,41 @@ impl OptdQueryPlannerContext<'_> {
         Ok(nary_expr)
     }
 
-    pub fn try_from_optd_cast(&mut self, node: CastBorrowed<'_>) -> Result<DFExpr> {
-        let input = self.try_from_optd_scalar_expr(node.expr())?;
+    pub fn try_from_optd_cast(
+        &mut self,
+        node: CastBorrowed<'_>,
+        output_env: &OutputEnv,
+    ) -> Result<DFExpr> {
+        let input = self.try_from_optd_scalar_expr_with_env(node.expr(), output_env)?;
         let cast = logical_expr::cast(input, node.data_type().clone());
         Ok(cast)
     }
 
-    pub fn try_from_optd_is_null(&mut self, node: IsNullBorrowed<'_>) -> Result<DFExpr> {
-        let expr = self.try_from_optd_scalar_expr(node.expr())?;
+    pub fn try_from_optd_is_null(
+        &mut self,
+        node: IsNullBorrowed<'_>,
+        output_env: &OutputEnv,
+    ) -> Result<DFExpr> {
+        let expr = self.try_from_optd_scalar_expr_with_env(node.expr(), output_env)?;
         Ok(DFExpr::IsNull(Box::new(expr)))
     }
 
-    pub fn try_from_optd_is_not_null(&mut self, node: IsNotNullBorrowed<'_>) -> Result<DFExpr> {
-        let expr = self.try_from_optd_scalar_expr(node.expr())?;
+    pub fn try_from_optd_is_not_null(
+        &mut self,
+        node: IsNotNullBorrowed<'_>,
+        output_env: &OutputEnv,
+    ) -> Result<DFExpr> {
+        let expr = self.try_from_optd_scalar_expr_with_env(node.expr(), output_env)?;
         Ok(DFExpr::IsNotNull(Box::new(expr)))
     }
 
-    pub fn try_from_optd_like(&mut self, node: LikeBorrowed<'_>) -> Result<DFExpr> {
-        let input = self.try_from_optd_scalar_expr(node.expr())?;
-        let pattern = self.try_from_optd_scalar_expr(node.pattern())?;
+    pub fn try_from_optd_like(
+        &mut self,
+        node: LikeBorrowed<'_>,
+        output_env: &OutputEnv,
+    ) -> Result<DFExpr> {
+        let input = self.try_from_optd_scalar_expr_with_env(node.expr(), output_env)?;
+        let pattern = self.try_from_optd_scalar_expr_with_env(node.pattern(), output_env)?;
         let like = logical_expr::Like::new(
             *node.negated(),
             Box::new(input),
@@ -1248,11 +1274,15 @@ impl OptdQueryPlannerContext<'_> {
         Ok(DFExpr::Like(like))
     }
 
-    pub fn try_from_optd_function(&mut self, node: FunctionBorrowed<'_>) -> Result<DFExpr> {
+    pub fn try_from_optd_function(
+        &mut self,
+        node: FunctionBorrowed<'_>,
+        output_env: &OutputEnv,
+    ) -> Result<DFExpr> {
         let args = node
             .params()
             .iter()
-            .map(|e| self.try_from_optd_scalar_expr(e))
+            .map(|e| self.try_from_optd_scalar_expr_with_env(e, output_env))
             .try_collect()?;
 
         match node.kind() {
@@ -1287,24 +1317,28 @@ impl OptdQueryPlannerContext<'_> {
         }
     }
 
-    pub fn try_from_optd_case(&mut self, node: CaseBorrowed<'_>) -> Result<DFExpr> {
+    pub fn try_from_optd_case(
+        &mut self,
+        node: CaseBorrowed<'_>,
+        output_env: &OutputEnv,
+    ) -> Result<DFExpr> {
         let expr = node
             .expr()
-            .map(|expr| self.try_from_optd_scalar_expr(expr))
+            .map(|expr| self.try_from_optd_scalar_expr_with_env(expr, output_env))
             .transpose()?
             .map(Box::new);
         let when_then_expr = node
             .when_then_expr()
             .map(|(when, then)| {
                 Ok((
-                    Box::new(self.try_from_optd_scalar_expr(when)?),
-                    Box::new(self.try_from_optd_scalar_expr(then)?),
+                    Box::new(self.try_from_optd_scalar_expr_with_env(when, output_env)?),
+                    Box::new(self.try_from_optd_scalar_expr_with_env(then, output_env)?),
                 ))
             })
             .try_collect()?;
         let else_expr = node
             .else_expr()
-            .map(|expr| self.try_from_optd_scalar_expr(expr))
+            .map(|expr| self.try_from_optd_scalar_expr_with_env(expr, output_env))
             .transpose()?
             .map(Box::new);
 
@@ -1315,13 +1349,17 @@ impl OptdQueryPlannerContext<'_> {
         )))
     }
 
-    pub fn try_from_optd_in_list(&mut self, node: InListBorrowed<'_>) -> Result<DFExpr> {
-        let expr = self.try_from_optd_scalar_expr(node.expr())?;
+    pub fn try_from_optd_in_list(
+        &mut self,
+        node: InListBorrowed<'_>,
+        output_env: &OutputEnv,
+    ) -> Result<DFExpr> {
+        let expr = self.try_from_optd_scalar_expr_with_env(node.expr(), output_env)?;
         let list = node.list().borrow::<List>();
         let list = list
             .members()
             .iter()
-            .map(|e| self.try_from_optd_scalar_expr(e))
+            .map(|e| self.try_from_optd_scalar_expr_with_env(e, output_env))
             .try_collect()?;
 
         Ok(DFExpr::InList(logical_expr::expr::InList::new(

--- a/connectors/datafusion/src/planner/from_optd.rs
+++ b/connectors/datafusion/src/planner/from_optd.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, vec};
+use std::{collections::HashMap, sync::Arc, vec};
 
 use datafusion::{
     common::{Column, DFSchema},
@@ -81,8 +81,38 @@ impl OptdQueryPlannerContext<'_> {
         let optd_schema = binding.optd_schema();
         let exprs = Self::alias_exprs_for_schema(exprs, &optd_schema)?;
         let schema = Self::df_schema_from_optd_schema(&optd_schema)?;
-        logical_expr::Projection::try_new_with_schema(exprs, input, Arc::new(schema))
-            .context(DataFusionSnafu)
+        Ok(logical_expr::Projection::try_new_with_schema(exprs, input, Arc::new(schema)).unwrap())
+    }
+
+    fn visible_column_scope(
+        &self,
+        input: &Operator,
+    ) -> Result<HashMap<optd_core::ir::Column, Column>> {
+        let columns = input
+            .output_columns_in_order(&self.inner)
+            .context(OptdSnafu)?;
+        let schema = input.output_schema(&self.inner).context(OptdSnafu)?;
+        Ok(columns
+            .into_iter()
+            .zip(schema.iter())
+            .map(|(column, (table_ref, field))| {
+                (
+                    column,
+                    Column::new(Some(Self::from_optd_table_ref(table_ref)), field.name()),
+                )
+            })
+            .collect())
+    }
+
+    fn with_visible_column_scope<T>(
+        &mut self,
+        scope: HashMap<optd_core::ir::Column, Column>,
+        f: impl FnOnce(&mut Self) -> Result<T>,
+    ) -> Result<T> {
+        self.from_optd_column_scopes.push(scope);
+        let result = f(self);
+        self.from_optd_column_scopes.pop();
+        result
     }
 
     fn alias_if_changed(expr: DFExpr, table_ref: &TableRef, field: &Field) -> Result<DFExpr> {
@@ -168,16 +198,20 @@ impl OptdQueryPlannerContext<'_> {
 
         let keys = node.keys().borrow::<List>();
         let exprs = node.exprs().borrow::<List>();
-        let group_expr = keys
-            .members()
-            .iter()
-            .map(|e| self.try_from_optd_scalar_expr(e))
-            .try_collect()?;
-        let aggr_expr = exprs
-            .members()
-            .iter()
-            .map(|e| self.try_from_optd_scalar_expr(e))
-            .try_collect()?;
+        let scope = self.visible_column_scope(node.input())?;
+        let (group_expr, aggr_expr) = self.with_visible_column_scope(scope, |this| {
+            let group_expr = keys
+                .members()
+                .iter()
+                .map(|e| this.try_from_optd_scalar_expr(e))
+                .try_collect()?;
+            let aggr_expr = exprs
+                .members()
+                .iter()
+                .map(|e| this.try_from_optd_scalar_expr(e))
+                .try_collect()?;
+            Ok((group_expr, aggr_expr))
+        })?;
 
         let aggregate =
             self.try_new_df_aggregate(&output_schema, Arc::new(input), group_expr, aggr_expr)?;
@@ -202,11 +236,14 @@ impl OptdQueryPlannerContext<'_> {
     pub fn try_from_optd_project(&mut self, node: ProjectBorrowed<'_>) -> Result<DFLogicalPlan> {
         let input = self.try_from_optd_plan(node.input())?;
         let projection_list = node.projections().borrow::<List>();
-        let exprs = projection_list
-            .members()
-            .iter()
-            .map(|e| self.try_from_optd_scalar_expr(e))
-            .try_collect()?;
+        let scope = self.visible_column_scope(node.input())?;
+        let exprs = self.with_visible_column_scope(scope, |this| {
+            projection_list
+                .members()
+                .iter()
+                .map(|e| this.try_from_optd_scalar_expr(e))
+                .try_collect()
+        })?;
 
         let projection = self.try_new_df_projection(node.table_index(), exprs, Arc::new(input))?;
 
@@ -219,19 +256,24 @@ impl OptdQueryPlannerContext<'_> {
         let (equi_conds, non_equi_conds) =
             split_equi_and_non_equi_conditions(&node, &self.inner).context(OptdSnafu)?;
 
-        let on = equi_conds
-            .iter()
-            .map(|(l, r)| {
-                Ok((
-                    DFExpr::Column(self.try_from_optd_column(l)?),
-                    DFExpr::Column(self.try_from_optd_column(r)?),
-                ))
-            })
-            .try_collect()?;
-        let filter: Vec<_> = non_equi_conds
-            .iter()
-            .map(|e| self.try_from_optd_scalar_expr(e))
-            .try_collect()?;
+        let mut scope = self.visible_column_scope(node.outer())?;
+        scope.extend(self.visible_column_scope(node.inner())?);
+        let (on, filter): (_, Vec<_>) = self.with_visible_column_scope(scope, |this| {
+            let on = equi_conds
+                .iter()
+                .map(|(l, r)| {
+                    Ok((
+                        DFExpr::Column(this.try_from_optd_column(l)?),
+                        DFExpr::Column(this.try_from_optd_column(r)?),
+                    ))
+                })
+                .try_collect()?;
+            let filter = non_equi_conds
+                .iter()
+                .map(|e| this.try_from_optd_scalar_expr(e))
+                .try_collect()?;
+            Ok((on, filter))
+        })?;
 
         let filter = filter.into_iter().reduce(logical_expr::and);
 
@@ -262,7 +304,10 @@ impl OptdQueryPlannerContext<'_> {
 
     pub fn try_from_optd_select(&mut self, node: SelectBorrowed<'_>) -> Result<DFLogicalPlan> {
         let input = self.try_from_optd_plan(node.input())?;
-        let predicate = self.try_from_optd_scalar_expr(node.predicate())?;
+        let scope = self.visible_column_scope(node.input())?;
+        let predicate = self.with_visible_column_scope(scope, |this| {
+            this.try_from_optd_scalar_expr(node.predicate())
+        })?;
         let filter =
             logical_plan::Filter::try_new(predicate, Arc::new(input)).context(DataFusionSnafu)?;
         Ok(DFLogicalPlan::Filter(filter))
@@ -296,15 +341,17 @@ impl OptdQueryPlannerContext<'_> {
         node: EnforcerSortBorrowed<'_>,
     ) -> Result<DFLogicalPlan> {
         let input = self.try_from_optd_plan(node.input())?;
-        let expr = node
-            .tuple_ordering()
-            .iter()
-            .map(|(column, direction)| {
-                let expr = DFExpr::Column(self.try_from_optd_column(column)?);
-                let asc = matches!(direction, TupleOrderingDirection::Asc);
-                Ok(logical_expr::expr::Sort::new(expr, asc, !asc))
-            })
-            .try_collect()?;
+        let scope = self.visible_column_scope(node.input())?;
+        let expr = self.with_visible_column_scope(scope, |this| {
+            node.tuple_ordering()
+                .iter()
+                .map(|(column, direction)| {
+                    let expr = DFExpr::Column(this.try_from_optd_column(column)?);
+                    let asc = matches!(direction, TupleOrderingDirection::Asc);
+                    Ok(logical_expr::expr::Sort::new(expr, asc, !asc))
+                })
+                .try_collect()
+        })?;
 
         Ok(DFLogicalPlan::Sort(logical_plan::Sort {
             expr,

--- a/connectors/datafusion/src/planner/from_optd.rs
+++ b/connectors/datafusion/src/planner/from_optd.rs
@@ -30,11 +30,17 @@ use optd_core::ir::{
 };
 use snafu::{OptionExt, ResultExt, whatever};
 
-use crate::planner::{DataFusionSnafu, OptdQueryPlannerContext, OptdSnafu, Result};
+use crate::planner::{
+    ConvertedPlan, DataFusionSnafu, OptdQueryPlannerContext, OptdSnafu, OutputEnv, Result,
+};
 
 impl OptdQueryPlannerContext<'_> {
     pub fn try_from_optd_plan(&mut self, optd_plan: &Operator) -> Result<DFLogicalPlan> {
-        match &optd_plan.kind {
+        Ok(self.try_from_optd_plan_with_outputs(optd_plan)?.plan)
+    }
+
+    fn try_from_optd_plan_with_outputs(&mut self, optd_plan: &Operator) -> Result<ConvertedPlan> {
+        let plan = match &optd_plan.kind {
             OperatorKind::Get(meta) => {
                 let node = Get::borrow_raw_parts(meta, &optd_plan.common);
                 self.try_from_optd_get(node)
@@ -68,7 +74,35 @@ impl OptdQueryPlannerContext<'_> {
                 self.try_from_optd_enforcer_sort(node)
             }
             kind => whatever!("unsupported operator type {kind:?}"),
+        }?;
+
+        let outputs = self.build_output_env(optd_plan, &plan)?;
+        Ok(ConvertedPlan { plan, outputs })
+    }
+
+    fn build_output_env(&self, optd_plan: &Operator, plan: &DFLogicalPlan) -> Result<OutputEnv> {
+        let columns = optd_plan
+            .output_columns_in_order(&self.inner)
+            .context(OptdSnafu)?;
+        let schema = plan.schema();
+        let fields = schema.iter().collect_vec();
+
+        if columns.len() != fields.len() {
+            whatever!(
+                "optd output columns ({}) do not match DataFusion schema fields ({}) for {:?}",
+                columns.len(),
+                fields.len(),
+                optd_plan.kind
+            );
         }
+
+        Ok(columns
+            .into_iter()
+            .zip(fields)
+            .map(|(column, (qualifier, field))| {
+                (column, Column::new(qualifier.cloned(), field.name()))
+            })
+            .collect())
     }
 
     fn try_new_df_projection(

--- a/connectors/datafusion/src/planner/from_optd.rs
+++ b/connectors/datafusion/src/planner/from_optd.rs
@@ -120,7 +120,11 @@ impl OptdQueryPlannerContext<'_> {
 
     fn merge_output_envs(&self, left: &OutputEnv, right: &OutputEnv) -> OutputEnv {
         let mut merged = left.clone();
-        merged.extend(right.iter().map(|(column, df_column)| (*column, df_column.clone())));
+        merged.extend(
+            right
+                .iter()
+                .map(|(column, df_column)| (*column, df_column.clone())),
+        );
         merged
     }
 
@@ -292,9 +296,10 @@ impl OptdQueryPlannerContext<'_> {
 
     pub fn try_from_optd_select(&mut self, node: SelectBorrowed<'_>) -> Result<DFLogicalPlan> {
         let input = self.try_from_optd_plan_with_outputs(node.input())?;
-        let predicate = self.try_from_optd_scalar_expr_with_env(node.predicate(), &input.outputs)?;
-        let filter =
-            logical_plan::Filter::try_new(predicate, Arc::new(input.plan)).context(DataFusionSnafu)?;
+        let predicate =
+            self.try_from_optd_scalar_expr_with_env(node.predicate(), &input.outputs)?;
+        let filter = logical_plan::Filter::try_new(predicate, Arc::new(input.plan))
+            .context(DataFusionSnafu)?;
         Ok(DFLogicalPlan::Filter(filter))
     }
 
@@ -330,7 +335,8 @@ impl OptdQueryPlannerContext<'_> {
             .tuple_ordering()
             .iter()
             .map(|(column, direction)| {
-                let expr = DFExpr::Column(self.try_from_optd_column_in_env(column, &input.outputs)?);
+                let expr =
+                    DFExpr::Column(self.try_from_optd_column_in_env(column, &input.outputs)?);
                 let asc = matches!(direction, TupleOrderingDirection::Asc);
                 Ok(logical_expr::expr::Sort::new(expr, asc, !asc))
             })

--- a/connectors/datafusion/src/planner/from_optd.rs
+++ b/connectors/datafusion/src/planner/from_optd.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc, vec};
+use std::{sync::Arc, vec};
 
 use datafusion::{
     common::{Column, DFSchema},
@@ -118,35 +118,10 @@ impl OptdQueryPlannerContext<'_> {
         Ok(logical_expr::Projection::try_new_with_schema(exprs, input, Arc::new(schema)).unwrap())
     }
 
-    fn visible_column_scope(
-        &self,
-        input: &Operator,
-    ) -> Result<HashMap<optd_core::ir::Column, Column>> {
-        let columns = input
-            .output_columns_in_order(&self.inner)
-            .context(OptdSnafu)?;
-        let schema = input.output_schema(&self.inner).context(OptdSnafu)?;
-        Ok(columns
-            .into_iter()
-            .zip(schema.iter())
-            .map(|(column, (table_ref, field))| {
-                (
-                    column,
-                    Column::new(Some(Self::from_optd_table_ref(table_ref)), field.name()),
-                )
-            })
-            .collect())
-    }
-
-    fn with_visible_column_scope<T>(
-        &mut self,
-        scope: HashMap<optd_core::ir::Column, Column>,
-        f: impl FnOnce(&mut Self) -> Result<T>,
-    ) -> Result<T> {
-        self.from_optd_column_scopes.push(scope);
-        let result = f(self);
-        self.from_optd_column_scopes.pop();
-        result
+    fn merge_output_envs(&self, left: &OutputEnv, right: &OutputEnv) -> OutputEnv {
+        let mut merged = left.clone();
+        merged.extend(right.iter().map(|(column, df_column)| (*column, df_column.clone())));
+        merged
     }
 
     fn alias_if_changed(expr: DFExpr, table_ref: &TableRef, field: &Field) -> Result<DFExpr> {
@@ -248,7 +223,7 @@ impl OptdQueryPlannerContext<'_> {
         Ok(DFLogicalPlan::Aggregate(aggregate))
     }
     pub fn try_from_optd_remap(&mut self, node: RemapBorrowed<'_>) -> Result<DFLogicalPlan> {
-        let input = self.try_from_optd_plan(node.input())?;
+        let input = self.try_from_optd_plan_with_outputs(node.input())?;
         let binder = self.inner.binder.read().unwrap();
         let binding = binder
             .get_binding(node.table_index())
@@ -257,7 +232,7 @@ impl OptdQueryPlannerContext<'_> {
 
         let alias = Self::from_optd_table_ref(table_ref);
 
-        let subquery_alias = logical_plan::SubqueryAlias::try_new(Arc::new(input), alias)
+        let subquery_alias = logical_plan::SubqueryAlias::try_new(Arc::new(input.plan), alias)
             .context(DataFusionSnafu)?;
 
         Ok(DFLogicalPlan::SubqueryAlias(subquery_alias))
@@ -279,36 +254,32 @@ impl OptdQueryPlannerContext<'_> {
     }
 
     pub fn try_from_optd_join(&mut self, node: JoinBorrowed<'_>) -> Result<DFLogicalPlan> {
-        let outer = self.try_from_optd_plan(node.outer())?;
-        let inner = self.try_from_optd_plan(node.inner())?;
+        let outer = self.try_from_optd_plan_with_outputs(node.outer())?;
+        let inner = self.try_from_optd_plan_with_outputs(node.inner())?;
         let (equi_conds, non_equi_conds) =
             split_equi_and_non_equi_conditions(&node, &self.inner).context(OptdSnafu)?;
 
-        let mut scope = self.visible_column_scope(node.outer())?;
-        scope.extend(self.visible_column_scope(node.inner())?);
-        let (on, filter): (_, Vec<_>) = self.with_visible_column_scope(scope, |ctx| {
-            let on = equi_conds
-                .iter()
-                .map(|(l, r)| {
-                    Ok((
-                        DFExpr::Column(ctx.try_from_optd_column(l)?),
-                        DFExpr::Column(ctx.try_from_optd_column(r)?),
-                    ))
-                })
-                .try_collect()?;
-            let filter = non_equi_conds
-                .iter()
-                .map(|e| ctx.try_from_optd_scalar_expr(e))
-                .try_collect()?;
-            Ok((on, filter))
-        })?;
+        let output_env = self.merge_output_envs(&outer.outputs, &inner.outputs);
+        let on = equi_conds
+            .iter()
+            .map(|(l, r)| {
+                Ok((
+                    DFExpr::Column(self.try_from_optd_column_in_env(l, &output_env)?),
+                    DFExpr::Column(self.try_from_optd_column_in_env(r, &output_env)?),
+                ))
+            })
+            .try_collect()?;
+        let filter: Vec<_> = non_equi_conds
+            .iter()
+            .map(|e| self.try_from_optd_scalar_expr_with_env(e, &output_env))
+            .try_collect()?;
 
         let filter = filter.into_iter().reduce(logical_expr::and);
 
         let join_type = Self::try_from_optd_join_type(node.join_type())?;
         let join = logical_plan::Join::try_new(
-            Arc::new(outer),
-            Arc::new(inner),
+            Arc::new(outer.plan),
+            Arc::new(inner.plan),
             on,
             filter,
             join_type,
@@ -316,17 +287,6 @@ impl OptdQueryPlannerContext<'_> {
             datafusion::common::NullEquality::NullEqualsNothing,
         )
         .context(DataFusionSnafu)?;
-        if let optd_core::ir::operator::join::JoinType::Mark(mark_column) = node.join_type() {
-            let (qualifier, field) = join
-                .schema
-                .iter()
-                .last()
-                .with_whatever_context(|| "LeftMark join should expose a marker column")?;
-            self.register_optd_mark_column(
-                *mark_column,
-                Column::new(qualifier.cloned(), field.name()),
-            );
-        }
         Ok(DFLogicalPlan::Join(join))
     }
 
@@ -1077,6 +1037,7 @@ mod tests {
 }
 
 impl OptdQueryPlannerContext<'_> {
+    #[cfg(test)]
     pub fn try_from_optd_scalar_expr(&mut self, expr: &Scalar) -> Result<DFExpr> {
         let output_env = OutputEnv::default();
         self.try_from_optd_scalar_expr_with_env(expr, &output_env)

--- a/connectors/datafusion/src/planner/mod.rs
+++ b/connectors/datafusion/src/planner/mod.rs
@@ -72,6 +72,7 @@ pub struct OptdQueryPlannerContext<'a> {
     pub table_reference_to_source: HashMap<TableReference, Arc<dyn TableSource + 'static>>,
     pub df_mark_columns: HashMap<datafusion::common::Column, optd_core::ir::Column>,
     pub optd_mark_columns: HashMap<optd_core::ir::Column, datafusion::common::Column>,
+    pub from_optd_column_scopes: Vec<HashMap<optd_core::ir::Column, datafusion::common::Column>>,
 }
 
 impl<'a> OptdQueryPlannerContext<'a> {
@@ -82,6 +83,7 @@ impl<'a> OptdQueryPlannerContext<'a> {
             table_reference_to_source: HashMap::new(),
             df_mark_columns: HashMap::new(),
             optd_mark_columns: HashMap::new(),
+            from_optd_column_scopes: Vec::new(),
         }
     }
 
@@ -296,6 +298,15 @@ impl OptdQueryPlanner {
                 return Err(DataFusionError::External(e.into()));
             }
         };
+
+        println!(
+            "optd_logical:\n{}",
+            quick_explain(&optd_logical, &ctx.inner)
+        );
+        println!(
+            "optd_physical:\n{}",
+            quick_explain(&optd_physical, &ctx.inner)
+        );
 
         let logical_plan = ctx
             .try_from_optd_plan(&optd_physical)

--- a/connectors/datafusion/src/planner/mod.rs
+++ b/connectors/datafusion/src/planner/mod.rs
@@ -66,6 +66,13 @@ pub enum OptdDFConnectorError {
 
 pub type Result<T> = std::result::Result<T, OptdDFConnectorError>;
 
+pub type OutputEnv = HashMap<optd_core::ir::Column, datafusion::common::Column>;
+
+pub struct ConvertedPlan {
+    pub plan: LogicalPlan,
+    pub outputs: OutputEnv,
+}
+
 pub struct OptdQueryPlannerContext<'a> {
     pub inner: Arc<IRContext>,
     pub session_state: &'a SessionState,

--- a/connectors/datafusion/src/planner/mod.rs
+++ b/connectors/datafusion/src/planner/mod.rs
@@ -78,8 +78,6 @@ pub struct OptdQueryPlannerContext<'a> {
     pub session_state: &'a SessionState,
     pub table_reference_to_source: HashMap<TableReference, Arc<dyn TableSource + 'static>>,
     pub df_mark_columns: HashMap<datafusion::common::Column, optd_core::ir::Column>,
-    pub optd_mark_columns: HashMap<optd_core::ir::Column, datafusion::common::Column>,
-    pub from_optd_column_scopes: Vec<HashMap<optd_core::ir::Column, datafusion::common::Column>>,
 }
 
 impl<'a> OptdQueryPlannerContext<'a> {
@@ -89,8 +87,6 @@ impl<'a> OptdQueryPlannerContext<'a> {
             session_state,
             table_reference_to_source: HashMap::new(),
             df_mark_columns: HashMap::new(),
-            optd_mark_columns: HashMap::new(),
-            from_optd_column_scopes: Vec::new(),
         }
     }
 

--- a/connectors/datafusion/src/planner/utils.rs
+++ b/connectors/datafusion/src/planner/utils.rs
@@ -77,10 +77,6 @@ impl OptdQueryPlannerContext<'_> {
     }
 
     pub fn try_from_optd_column(&self, column: &Column) -> Result<DFColumn> {
-        // Check for mark columns first
-        if let Some(df_column) = self.optd_mark_columns.get(column) {
-            return Ok(df_column.clone());
-        }
         let (table_ref, field) = self.inner.get_column_name(column).context(OptdSnafu)?;
         let table_reference = Self::from_optd_table_ref(&table_ref);
         let column = DFColumn::new(Some(table_reference), field.name());
@@ -102,11 +98,6 @@ impl OptdQueryPlannerContext<'_> {
     /// Registers the optd column allocated for a DataFusion mark column.
     pub fn register_df_mark_column(&mut self, df_column: DFColumn, column: Column) {
         self.df_mark_columns.insert(df_column, column);
-    }
-
-    /// Registers the DataFusion mark column associated with an optd column.
-    pub fn register_optd_mark_column(&mut self, column: Column, df_column: DFColumn) {
-        self.optd_mark_columns.insert(column, df_column);
     }
 
     /// Returns the existing optd column for a DataFusion mark column, or allocates one.

--- a/connectors/datafusion/src/planner/utils.rs
+++ b/connectors/datafusion/src/planner/utils.rs
@@ -81,6 +81,12 @@ impl OptdQueryPlannerContext<'_> {
         if let Some(df_column) = self.optd_mark_columns.get(column) {
             return Ok(df_column.clone());
         }
+        for scope in self.from_optd_column_scopes.iter().rev() {
+            if let Some(df_column) = scope.get(column) {
+                return Ok(df_column.clone());
+            }
+        }
+
         let (table_ref, field) = self.inner.get_column_name(column).context(OptdSnafu)?;
         let table_reference = Self::from_optd_table_ref(&table_ref);
         let column = DFColumn::new(Some(table_reference), field.name());

--- a/connectors/datafusion/src/planner/utils.rs
+++ b/connectors/datafusion/src/planner/utils.rs
@@ -12,7 +12,7 @@ use optd_core::ir::{
 use snafu::{ResultExt, whatever};
 use std::sync::Arc;
 
-use crate::planner::{OptdQueryPlannerContext, OptdSnafu, Result};
+use crate::planner::{OptdQueryPlannerContext, OptdSnafu, OutputEnv, Result};
 
 impl OptdQueryPlannerContext<'_> {
     pub fn into_optd_table_ref(table_ref: &TableReference) -> TableRef {
@@ -81,16 +81,22 @@ impl OptdQueryPlannerContext<'_> {
         if let Some(df_column) = self.optd_mark_columns.get(column) {
             return Ok(df_column.clone());
         }
-        for scope in self.from_optd_column_scopes.iter().rev() {
-            if let Some(df_column) = scope.get(column) {
-                return Ok(df_column.clone());
-            }
-        }
-
         let (table_ref, field) = self.inner.get_column_name(column).context(OptdSnafu)?;
         let table_reference = Self::from_optd_table_ref(&table_ref);
         let column = DFColumn::new(Some(table_reference), field.name());
         Ok(column)
+    }
+
+    pub fn try_from_optd_column_in_env(
+        &self,
+        column: &Column,
+        output_env: &OutputEnv,
+    ) -> Result<DFColumn> {
+        if let Some(df_column) = output_env.get(column) {
+            return Ok(df_column.clone());
+        }
+
+        self.try_from_optd_column(column)
     }
 
     /// Registers the optd column allocated for a DataFusion mark column.

--- a/optd/core/src/rules/decorrelation/d_join.rs
+++ b/optd/core/src/rules/decorrelation/d_join.rs
@@ -31,7 +31,7 @@ use crate::ir::convert::{IntoOperator, IntoScalar};
 use crate::ir::operator::join::JoinType;
 use crate::ir::operator::{Aggregate, DependentJoinBorrowed, Join, Operator};
 use crate::ir::scalar::{BinaryOp, BinaryOpKind, ColumnRef};
-use crate::ir::{Column, Scalar};
+use crate::ir::{Column, Scalar, ScalarKind};
 
 use super::UnnestingRule;
 use super::helpers::{
@@ -39,6 +39,28 @@ use super::helpers::{
 };
 
 impl UnnestingRule {
+    fn remap_scalar_columns(scalar: Arc<Scalar>, remap: &HashMap<Column, Column>) -> Arc<Scalar> {
+        let rewritten = match &scalar.kind {
+            ScalarKind::ColumnRef(cr) => {
+                ColumnRef::new(remap.get(&cr.column).copied().unwrap_or(cr.column)).into_scalar()
+            }
+            _ => {
+                let new_inputs = scalar
+                    .input_scalars()
+                    .iter()
+                    .map(|s| Self::remap_scalar_columns(s.clone(), remap))
+                    .collect::<Vec<_>>();
+
+                if new_inputs != scalar.input_scalars() {
+                    Arc::new(scalar.clone_with_inputs(Some(Arc::from(new_inputs)), None))
+                } else {
+                    scalar
+                }
+            }
+        };
+        rewritten.simplify_nary_scalar()
+    }
+
     // Creates the domain for the new unnesting struct
     fn create_domain(
         &self,
@@ -133,6 +155,7 @@ impl UnnestingRule {
         let new_outer_cols = new_outer.output_columns(ctx)?;
         let (new_inner, remap) =
             remap_right_output_collisions(new_outer_cols.as_ref(), new_inner, &mut unnesting, ctx)?;
+        let condition = Self::remap_scalar_columns(unnesting.rewrite_columns(condition), &remap);
 
         // Add equality to join condition
         let mut new_conds = Vec::new();

--- a/optd/core/src/rules/decorrelation/helpers.rs
+++ b/optd/core/src/rules/decorrelation/helpers.rs
@@ -81,6 +81,10 @@ pub(super) struct Unnesting<'a> {
 
     /// Representatives discovered for columns that belong to ancestor scopes.
     nested_repr: HashMap<Column, Column>,
+
+    /// Rebuilt operators allocate fresh output column ids. This map remembers
+    /// which old output columns are now represented by which fresh columns.
+    column_rewrites: HashMap<Column, Column>,
 }
 
 impl<'a> Unnesting<'a> {
@@ -88,6 +92,7 @@ impl<'a> Unnesting<'a> {
         Self {
             repr: HashMap::new(),
             nested_repr: HashMap::new(),
+            column_rewrites: HashMap::new(),
             cclasses: UnionFind::default(),
             info,
         }
@@ -154,6 +159,23 @@ impl<'a> Unnesting<'a> {
                 *val = *mapped;
             }
         }
+        for val in self.column_rewrites.values_mut() {
+            if let Some(mapped) = remap.get(val) {
+                *val = *mapped;
+            }
+        }
+    }
+
+    fn resolve_column_rewrite(&self, col: Column) -> Option<Column> {
+        let mut current = col;
+        let mut seen = HashSet::new();
+        while let Some(next) = self.column_rewrites.get(&current).copied() {
+            if !seen.insert(current) {
+                break;
+            }
+            current = next;
+        }
+        (current != col).then_some(current)
     }
 
     pub(super) fn resolve_domain_repr_recursive(&self, col: Column) -> Option<Column> {
@@ -165,8 +187,8 @@ impl<'a> Unnesting<'a> {
     }
 
     pub(super) fn resolve_col(&self, col: Column) -> Option<Column> {
-        self.get_resolved_repr_of(&col)
-            .copied()
+        self.resolve_column_rewrite(col)
+            .or_else(|| self.get_resolved_repr_of(&col).copied())
             .or_else(|| self.resolve_domain_repr_recursive(col))
     }
 
@@ -187,10 +209,19 @@ impl<'a> Unnesting<'a> {
     }
 
     // Project/remap/aggregate rebuilds create fresh table-index namespaces in
-    // the new IR. Preserve equivalence information by teaching the current
-    // scope which old output column now corresponds to which new one.
+    // the new IR. Remember which old output column now corresponds to which
+    // new one so later expressions do not keep referencing hidden columns.
+    pub(super) fn record_column_rewrites(&mut self, mapping: &HashMap<Column, Column>) {
+        for (source, target) in mapping {
+            self.column_rewrites.insert(*source, *target);
+        }
+    }
+
+    // Passthrough mappings are stronger than column rewrites: the source input
+    // column and target output column are equivalent for representative choice.
     pub(super) fn propagate_passthrough_mapping(&mut self, mapping: &HashMap<Column, Column>) {
         for (source, target) in mapping {
+            self.column_rewrites.insert(*source, *target);
             self.cclasses.merge(source, target);
         }
 

--- a/optd/core/src/rules/decorrelation/testing/unnesting_tests.rs
+++ b/optd/core/src/rules/decorrelation/testing/unnesting_tests.rs
@@ -717,40 +717,22 @@ fn test_nested_dep_join_regular_join_orderby_project_domain_vs_repr() -> Result<
         let t4c1 = t4_cols[1];
 
         let left_branch = mock_scan_with_columns(1, t1_cols.clone());
-        let (_input_left_project, input_left_outputs) = project_with_outputs(
-            &expected_ctx,
-            mock_scan_with_columns(3, t3_cols.clone()).logical_select(
-                column_ref(t3c0)
-                    .gt(column_ref(t2c0))
-                    .and(column_ref(t3c1).gt(column_ref(t1c0))),
-            ),
-            [column_ref(t3c0), column_ref(t3c1)],
-        )?;
-        let p3a = input_left_outputs[0];
-        let p3b = input_left_outputs[1];
-        let (_input_right_project, input_right_outputs) = project_with_outputs(
-            &expected_ctx,
-            mock_scan_with_columns(4, t4_cols.clone())
-                .logical_select(column_ref(t4c0).eq(column_ref(t2c0))),
-            [column_ref(t4c0), column_ref(t4c1)],
-        )?;
-        let p4b = input_right_outputs[1];
         let (right_branch, d1) = {
             let mid_left = mock_scan_with_columns(2, t2_cols.clone());
             let (mid_right, d1) = {
                 let left_regular = {
-                    let (current_domain, current_outputs) = create_domain_with_aliases(
-                        &expected_ctx,
-                        mock_scan_with_columns(2, t2_cols),
-                        vec![t2c0],
-                    )?;
-                    let d2 = current_outputs[0];
                     let (parent_domain, parent_outputs) = create_domain_with_aliases(
                         &expected_ctx,
                         mock_scan_with_columns(1, t1_cols),
                         vec![t1c0],
                     )?;
                     let d1 = parent_outputs[0];
+                    let (current_domain, current_outputs) = create_domain_with_aliases(
+                        &expected_ctx,
+                        mock_scan_with_columns(2, t2_cols),
+                        vec![t2c0],
+                    )?;
+                    let d2 = current_outputs[0];
                     let select_input = current_domain
                         .logical_join(parent_domain, boolean(true), JoinType::Inner)
                         .logical_join(
@@ -772,12 +754,13 @@ fn test_nested_dep_join_regular_join_orderby_project_domain_vs_repr() -> Result<
                     )?;
                     let ordered = OrderBy::new(
                         projected,
-                        vec![(column_ref(p3a), TupleOrderingDirection::Asc)],
+                        vec![(column_ref(projected_cols[0]), TupleOrderingDirection::Asc)],
                     )
                     .into_operator();
                     (ordered, projected_cols, d1)
                 };
                 let (left_regular, left_outputs, d1) = left_regular;
+                let p3b = left_outputs[1];
                 let d2 = left_outputs[3];
                 let (right_regular, right_outputs) = {
                     let select_input = mock_scan_with_columns(4, t4_cols)
@@ -790,6 +773,7 @@ fn test_nested_dep_join_regular_join_orderby_project_domain_vs_repr() -> Result<
                     (projected, projected_cols)
                 };
                 let p4a = right_outputs[0];
+                let p4b = right_outputs[1];
                 let inner_join = left_regular.logical_join(
                     right_regular,
                     column_ref(p3b)

--- a/optd/core/src/rules/decorrelation/unnest.rs
+++ b/optd/core/src/rules/decorrelation/unnest.rs
@@ -290,6 +290,7 @@ impl UnnestingRule {
                 )?;
                 let new_exprs = info.rewrite_columns(node.projections().clone());
                 let mut members = new_exprs.try_borrow::<List>().unwrap().members().to_vec();
+                let original_projection_len = members.len();
                 let mut passthrough_cols: HashSet<Column> = members
                     .iter()
                     .filter_map(|expr| expr.try_borrow::<ColumnRef>().ok().map(|col| *col.column()))
@@ -302,6 +303,15 @@ impl UnnestingRule {
                 }
                 let projected = ctx.project(new_input, members.clone())?.build();
                 let project_table_index = *projected.borrow::<Project>().table_index();
+                let output_rewrites = (0..original_projection_len)
+                    .map(|idx| {
+                        (
+                            Column(*node.table_index(), idx),
+                            Column(project_table_index, idx),
+                        )
+                    })
+                    .collect::<HashMap<_, _>>();
+                info.record_column_rewrites(&output_rewrites);
                 let passthrough_mapping = members
                     .iter()
                     .enumerate()
@@ -389,7 +399,19 @@ impl UnnestingRule {
                     .with_ctx(ctx)
                     .logical_aggregate(new_exprs_vec.clone(), new_keys_vec.clone())?
                     .build();
-                let key_table_index = *agg.borrow::<Aggregate>().key_table_index();
+                let (key_table_index, aggregate_table_index) = {
+                    let new_agg = agg.borrow::<Aggregate>();
+                    (*new_agg.key_table_index(), *new_agg.aggregate_table_index())
+                };
+                let output_rewrites = (0..new_exprs_vec.len())
+                    .map(|idx| {
+                        (
+                            Column(*node.aggregate_table_index(), idx),
+                            Column(aggregate_table_index, idx),
+                        )
+                    })
+                    .collect::<HashMap<_, _>>();
+                info.record_column_rewrites(&output_rewrites);
                 let passthrough_mapping = new_keys_vec
                     .iter()
                     .enumerate()

--- a/tests/sqlplannertest/tests/tpch/q17.planner.sql
+++ b/tests/sqlplannertest/tests/tpch/q17.planner.sql
@@ -19,6 +19,6 @@ WHERE
 
 /*
 Error
-Schema error: No field named "__#10".p_partkey.
+Schema error: No field named "__#5"."avg(lineitem.l_quantity)". Did you mean 'lineitem.l_partkey'?.
 */
 

--- a/tests/sqlplannertest/tests/tpch/q17.planner.sql
+++ b/tests/sqlplannertest/tests/tpch/q17.planner.sql
@@ -18,7 +18,315 @@ WHERE
     );
 
 /*
-Error
-Schema error: No field named "__#5"."avg(lineitem.l_quantity)". Did you mean 'lineitem.l_partkey'?.
+logical_plan after optd-initial:
+Project
+├── .table_index: 9
+├── .projections: round(CAST ("__#8.sum(lineitem.l_extendedprice)"(#8.0) AS Float64) / 7::float64, CAST (16::bigint AS Int32))
+├── (.output_columns): "__#9.avg_yearly"(#9.0)
+├── (.cardinality): 1.00
+└── Aggregate
+    ├── .key_table_index: 7
+    ├── .aggregate_table_index: 8
+    ├── .implementation: None
+    ├── .exprs: sum("lineitem.l_extendedprice"(#1.5))
+    ├── .keys: []
+    ├── (.output_columns): "__#8.sum(lineitem.l_extendedprice)"(#8.0)
+    ├── (.cardinality): 1.00
+    └── DependentJoin
+        ├── .join_type: Inner
+        ├── .join_cond: CAST ("lineitem.l_quantity"(#1.4) AS Decimal128(30, 15)) < "__#6.Float64(0.2) * avg(lineitem.l_quantity)"(#6.0)
+        ├── (.output_columns):
+        │   ┌── "__#6.Float64(0.2) * avg(lineitem.l_quantity)"(#6.0)
+        │   ├── "lineitem.l_comment"(#1.15)
+        │   ├── "lineitem.l_commitdate"(#1.11)
+        │   ├── "lineitem.l_discount"(#1.6)
+        │   ├── "lineitem.l_extendedprice"(#1.5)
+        │   ├── "lineitem.l_linenumber"(#1.3)
+        │   ├── "lineitem.l_linestatus"(#1.9)
+        │   ├── "lineitem.l_orderkey"(#1.0)
+        │   ├── "lineitem.l_partkey"(#1.1)
+        │   ├── "lineitem.l_quantity"(#1.4)
+        │   ├── "lineitem.l_receiptdate"(#1.12)
+        │   ├── "lineitem.l_returnflag"(#1.8)
+        │   ├── "lineitem.l_shipdate"(#1.10)
+        │   ├── "lineitem.l_shipinstruct"(#1.13)
+        │   ├── "lineitem.l_shipmode"(#1.14)
+        │   ├── "lineitem.l_suppkey"(#1.2)
+        │   ├── "lineitem.l_tax"(#1.7)
+        │   ├── "part.p_brand"(#2.3)
+        │   ├── "part.p_comment"(#2.8)
+        │   ├── "part.p_container"(#2.6)
+        │   ├── "part.p_mfgr"(#2.2)
+        │   ├── "part.p_name"(#2.1)
+        │   ├── "part.p_partkey"(#2.0)
+        │   ├── "part.p_retailprice"(#2.7)
+        │   ├── "part.p_size"(#2.5)
+        │   └── "part.p_type"(#2.4)
+        ├── (.cardinality): 0.00
+        ├── Select
+        │   ├── .predicate: ("part.p_partkey"(#2.0) = "lineitem.l_partkey"(#1.1)) AND ("part.p_brand"(#2.3) = CAST ('Brand#13'::utf8 AS Utf8View)) AND ("part.p_container"(#2.6) = CAST ('JUMBO PKG'::utf8 AS Utf8View))
+        │   ├── (.output_columns):
+        │   │   ┌── "lineitem.l_comment"(#1.15)
+        │   │   ├── "lineitem.l_commitdate"(#1.11)
+        │   │   ├── "lineitem.l_discount"(#1.6)
+        │   │   ├── "lineitem.l_extendedprice"(#1.5)
+        │   │   ├── "lineitem.l_linenumber"(#1.3)
+        │   │   ├── "lineitem.l_linestatus"(#1.9)
+        │   │   ├── "lineitem.l_orderkey"(#1.0)
+        │   │   ├── "lineitem.l_partkey"(#1.1)
+        │   │   ├── "lineitem.l_quantity"(#1.4)
+        │   │   ├── "lineitem.l_receiptdate"(#1.12)
+        │   │   ├── "lineitem.l_returnflag"(#1.8)
+        │   │   ├── "lineitem.l_shipdate"(#1.10)
+        │   │   ├── "lineitem.l_shipinstruct"(#1.13)
+        │   │   ├── "lineitem.l_shipmode"(#1.14)
+        │   │   ├── "lineitem.l_suppkey"(#1.2)
+        │   │   ├── "lineitem.l_tax"(#1.7)
+        │   │   ├── "part.p_brand"(#2.3)
+        │   │   ├── "part.p_comment"(#2.8)
+        │   │   ├── "part.p_container"(#2.6)
+        │   │   ├── "part.p_mfgr"(#2.2)
+        │   │   ├── "part.p_name"(#2.1)
+        │   │   ├── "part.p_partkey"(#2.0)
+        │   │   ├── "part.p_retailprice"(#2.7)
+        │   │   ├── "part.p_size"(#2.5)
+        │   │   └── "part.p_type"(#2.4)
+        │   ├── (.cardinality): 0.00
+        │   └── Join
+        │       ├── .join_type: Inner
+        │       ├── .implementation: None
+        │       ├── .join_cond: 
+        │       ├── (.output_columns):
+        │       │   ┌── "lineitem.l_comment"(#1.15)
+        │       │   ├── "lineitem.l_commitdate"(#1.11)
+        │       │   ├── "lineitem.l_discount"(#1.6)
+        │       │   ├── "lineitem.l_extendedprice"(#1.5)
+        │       │   ├── "lineitem.l_linenumber"(#1.3)
+        │       │   ├── "lineitem.l_linestatus"(#1.9)
+        │       │   ├── "lineitem.l_orderkey"(#1.0)
+        │       │   ├── "lineitem.l_partkey"(#1.1)
+        │       │   ├── "lineitem.l_quantity"(#1.4)
+        │       │   ├── "lineitem.l_receiptdate"(#1.12)
+        │       │   ├── "lineitem.l_returnflag"(#1.8)
+        │       │   ├── "lineitem.l_shipdate"(#1.10)
+        │       │   ├── "lineitem.l_shipinstruct"(#1.13)
+        │       │   ├── "lineitem.l_shipmode"(#1.14)
+        │       │   ├── "lineitem.l_suppkey"(#1.2)
+        │       │   ├── "lineitem.l_tax"(#1.7)
+        │       │   ├── "part.p_brand"(#2.3)
+        │       │   ├── "part.p_comment"(#2.8)
+        │       │   ├── "part.p_container"(#2.6)
+        │       │   ├── "part.p_mfgr"(#2.2)
+        │       │   ├── "part.p_name"(#2.1)
+        │       │   ├── "part.p_partkey"(#2.0)
+        │       │   ├── "part.p_retailprice"(#2.7)
+        │       │   ├── "part.p_size"(#2.5)
+        │       │   └── "part.p_type"(#2.4)
+        │       ├── (.cardinality): 0.00
+        │       ├── Get
+        │       │   ├── .data_source_id: 8
+        │       │   ├── .table_index: 1
+        │       │   ├── .implementation: None
+        │       │   ├── (.output_columns):
+        │       │   │   ┌── "lineitem.l_comment"(#1.15)
+        │       │   │   ├── "lineitem.l_commitdate"(#1.11)
+        │       │   │   ├── "lineitem.l_discount"(#1.6)
+        │       │   │   ├── "lineitem.l_extendedprice"(#1.5)
+        │       │   │   ├── "lineitem.l_linenumber"(#1.3)
+        │       │   │   ├── "lineitem.l_linestatus"(#1.9)
+        │       │   │   ├── "lineitem.l_orderkey"(#1.0)
+        │       │   │   ├── "lineitem.l_partkey"(#1.1)
+        │       │   │   ├── "lineitem.l_quantity"(#1.4)
+        │       │   │   ├── "lineitem.l_receiptdate"(#1.12)
+        │       │   │   ├── "lineitem.l_returnflag"(#1.8)
+        │       │   │   ├── "lineitem.l_shipdate"(#1.10)
+        │       │   │   ├── "lineitem.l_shipinstruct"(#1.13)
+        │       │   │   ├── "lineitem.l_shipmode"(#1.14)
+        │       │   │   ├── "lineitem.l_suppkey"(#1.2)
+        │       │   │   └── "lineitem.l_tax"(#1.7)
+        │       │   └── (.cardinality): 0.00
+        │       └── Get
+        │           ├── .data_source_id: 3
+        │           ├── .table_index: 2
+        │           ├── .implementation: None
+        │           ├── (.output_columns):
+        │           │   ┌── "part.p_brand"(#2.3)
+        │           │   ├── "part.p_comment"(#2.8)
+        │           │   ├── "part.p_container"(#2.6)
+        │           │   ├── "part.p_mfgr"(#2.2)
+        │           │   ├── "part.p_name"(#2.1)
+        │           │   ├── "part.p_partkey"(#2.0)
+        │           │   ├── "part.p_retailprice"(#2.7)
+        │           │   ├── "part.p_size"(#2.5)
+        │           │   └── "part.p_type"(#2.4)
+        │           └── (.cardinality): 0.00
+        └── Project
+            ├── .table_index: 6
+            ├── .projections: CAST (0.2::float64 * CAST ("__#5.avg(lineitem.l_quantity)"(#5.0) AS Float64) AS Decimal128(30, 15))
+            ├── (.output_columns): "__#6.Float64(0.2) * avg(lineitem.l_quantity)"(#6.0)
+            ├── (.cardinality): 1.00
+            └── Aggregate
+                ├── .key_table_index: 4
+                ├── .aggregate_table_index: 5
+                ├── .implementation: None
+                ├── .exprs: avg("lineitem.l_quantity"(#3.4))
+                ├── .keys: []
+                ├── (.output_columns): "__#5.avg(lineitem.l_quantity)"(#5.0)
+                ├── (.cardinality): 1.00
+                └── Select
+                    ├── .predicate: "lineitem.l_partkey"(#3.1) = "part.p_partkey"(#2.0)
+                    ├── (.output_columns):
+                    │   ┌── "lineitem.l_comment"(#3.15)
+                    │   ├── "lineitem.l_commitdate"(#3.11)
+                    │   ├── "lineitem.l_discount"(#3.6)
+                    │   ├── "lineitem.l_extendedprice"(#3.5)
+                    │   ├── "lineitem.l_linenumber"(#3.3)
+                    │   ├── "lineitem.l_linestatus"(#3.9)
+                    │   ├── "lineitem.l_orderkey"(#3.0)
+                    │   ├── "lineitem.l_partkey"(#3.1)
+                    │   ├── "lineitem.l_quantity"(#3.4)
+                    │   ├── "lineitem.l_receiptdate"(#3.12)
+                    │   ├── "lineitem.l_returnflag"(#3.8)
+                    │   ├── "lineitem.l_shipdate"(#3.10)
+                    │   ├── "lineitem.l_shipinstruct"(#3.13)
+                    │   ├── "lineitem.l_shipmode"(#3.14)
+                    │   ├── "lineitem.l_suppkey"(#3.2)
+                    │   └── "lineitem.l_tax"(#3.7)
+                    ├── (.cardinality): 0.00
+                    └── Get
+                        ├── .data_source_id: 8
+                        ├── .table_index: 3
+                        ├── .implementation: None
+                        ├── (.output_columns):
+                        │   ┌── "lineitem.l_comment"(#3.15)
+                        │   ├── "lineitem.l_commitdate"(#3.11)
+                        │   ├── "lineitem.l_discount"(#3.6)
+                        │   ├── "lineitem.l_extendedprice"(#3.5)
+                        │   ├── "lineitem.l_linenumber"(#3.3)
+                        │   ├── "lineitem.l_linestatus"(#3.9)
+                        │   ├── "lineitem.l_orderkey"(#3.0)
+                        │   ├── "lineitem.l_partkey"(#3.1)
+                        │   ├── "lineitem.l_quantity"(#3.4)
+                        │   ├── "lineitem.l_receiptdate"(#3.12)
+                        │   ├── "lineitem.l_returnflag"(#3.8)
+                        │   ├── "lineitem.l_shipdate"(#3.10)
+                        │   ├── "lineitem.l_shipinstruct"(#3.13)
+                        │   ├── "lineitem.l_shipmode"(#3.14)
+                        │   ├── "lineitem.l_suppkey"(#3.2)
+                        │   └── "lineitem.l_tax"(#3.7)
+                        └── (.cardinality): 0.00
+
+physical_plan after optd-finalized:
+Project
+├── .table_index: 9
+├── .projections: round(CAST ("__#8.sum(lineitem.l_extendedprice)"(#8.0) AS Float64) / 7::float64, 16::integer)
+├── (.output_columns): "__#9.avg_yearly"(#9.0)
+├── (.cardinality): 1.00
+└── Aggregate
+    ├── .key_table_index: 7
+    ├── .aggregate_table_index: 8
+    ├── .implementation: None
+    ├── .exprs: sum("lineitem.l_extendedprice"(#1.5))
+    ├── .keys: []
+    ├── (.output_columns): "__#8.sum(lineitem.l_extendedprice)"(#8.0)
+    ├── (.cardinality): 1.00
+    └── Join
+        ├── .join_type: Inner
+        ├── .implementation: None
+        ├── .join_cond: ("part.p_partkey"(#2.0) IS NOT DISTINCT FROM "__#14.p_partkey"(#14.1)) AND (CAST ("lineitem.l_quantity"(#1.4) AS Decimal128(30, 15)) < "__#14.expr0"(#14.0))
+        ├── (.output_columns):
+        │   ┌── "__#14.expr0"(#14.0)
+        │   ├── "__#14.p_partkey"(#14.1)
+        │   ├── "lineitem.l_extendedprice"(#1.5)
+        │   ├── "lineitem.l_partkey"(#1.1)
+        │   ├── "lineitem.l_quantity"(#1.4)
+        │   ├── "part.p_brand"(#2.3)
+        │   ├── "part.p_container"(#2.6)
+        │   └── "part.p_partkey"(#2.0)
+        ├── (.cardinality): 0.00
+        ├── Join
+        │   ├── .join_type: Inner
+        │   ├── .implementation: None
+        │   ├── .join_cond: "part.p_partkey"(#2.0) = "lineitem.l_partkey"(#1.1)
+        │   ├── (.output_columns):
+        │   │   ┌── "lineitem.l_extendedprice"(#1.5)
+        │   │   ├── "lineitem.l_partkey"(#1.1)
+        │   │   ├── "lineitem.l_quantity"(#1.4)
+        │   │   ├── "part.p_brand"(#2.3)
+        │   │   ├── "part.p_container"(#2.6)
+        │   │   └── "part.p_partkey"(#2.0)
+        │   ├── (.cardinality): 0.00
+        │   ├── Get
+        │   │   ├── .data_source_id: 8
+        │   │   ├── .table_index: 1
+        │   │   ├── .implementation: None
+        │   │   ├── (.output_columns): [ "lineitem.l_extendedprice"(#1.5), "lineitem.l_partkey"(#1.1), "lineitem.l_quantity"(#1.4) ]
+        │   │   └── (.cardinality): 0.00
+        │   └── Select
+        │       ├── .predicate: ("part.p_brand"(#2.3) = 'Brand#13'::utf8_view) AND ("part.p_container"(#2.6) = 'JUMBO PKG'::utf8_view)
+        │       ├── (.output_columns): [ "part.p_brand"(#2.3), "part.p_container"(#2.6), "part.p_partkey"(#2.0) ]
+        │       ├── (.cardinality): 0.00
+        │       └── Get
+        │           ├── .data_source_id: 3
+        │           ├── .table_index: 2
+        │           ├── .implementation: None
+        │           ├── (.output_columns): [ "part.p_brand"(#2.3), "part.p_container"(#2.6), "part.p_partkey"(#2.0) ]
+        │           └── (.cardinality): 0.00
+        └── Project
+            ├── .table_index: 14
+            ├── .projections: [ CAST (0.2::float64 * CAST ("__#13.avg"(#13.0) AS Float64) AS Decimal128(30, 15)), "__#10.p_partkey"(#10.0) ]
+            ├── (.output_columns): [ "__#14.expr0"(#14.0), "__#14.p_partkey"(#14.1) ]
+            ├── (.cardinality): 0.00
+            └── Join
+                ├── .join_type: LeftOuter
+                ├── .implementation: None
+                ├── .join_cond: "__#10.p_partkey"(#10.0) IS NOT DISTINCT FROM "__#12.l_partkey"(#12.0)
+                ├── (.output_columns): [ "__#10.p_partkey"(#10.0), "__#12.l_partkey"(#12.0), "__#13.avg"(#13.0) ]
+                ├── (.cardinality): 0.00
+                ├── Aggregate
+                │   ├── .key_table_index: 10
+                │   ├── .aggregate_table_index: 11
+                │   ├── .implementation: None
+                │   ├── .exprs: []
+                │   ├── .keys: "part.p_partkey"(#2.0)
+                │   ├── (.output_columns): "__#10.p_partkey"(#10.0)
+                │   ├── (.cardinality): 0.00
+                │   └── Join
+                │       ├── .join_type: Inner
+                │       ├── .implementation: None
+                │       ├── .join_cond: "part.p_partkey"(#2.0) = "lineitem.l_partkey"(#1.1)
+                │       ├── (.output_columns): [ "lineitem.l_partkey"(#1.1), "part.p_brand"(#2.3), "part.p_container"(#2.6), "part.p_partkey"(#2.0) ]
+                │       ├── (.cardinality): 0.00
+                │       ├── Get { .data_source_id: 8, .table_index: 1, .implementation: None, (.output_columns): "lineitem.l_partkey"(#1.1), (.cardinality): 0.00 }
+                │       └── Select
+                │           ├── .predicate: ("part.p_brand"(#2.3) = 'Brand#13'::utf8_view) AND ("part.p_container"(#2.6) = 'JUMBO PKG'::utf8_view)
+                │           ├── (.output_columns): [ "part.p_brand"(#2.3), "part.p_container"(#2.6), "part.p_partkey"(#2.0) ]
+                │           ├── (.cardinality): 0.00
+                │           └── Get
+                │               ├── .data_source_id: 3
+                │               ├── .table_index: 2
+                │               ├── .implementation: None
+                │               ├── (.output_columns): [ "part.p_brand"(#2.3), "part.p_container"(#2.6), "part.p_partkey"(#2.0) ]
+                │               └── (.cardinality): 0.00
+                └── Aggregate
+                    ├── .key_table_index: 12
+                    ├── .aggregate_table_index: 13
+                    ├── .implementation: None
+                    ├── .exprs: avg("lineitem.l_quantity"(#3.4))
+                    ├── .keys: "lineitem.l_partkey"(#3.1)
+                    ├── (.output_columns): [ "__#12.l_partkey"(#12.0), "__#13.avg"(#13.0) ]
+                    ├── (.cardinality): 0.00
+                    └── Select
+                        ├── .predicate: "lineitem.l_partkey"(#3.1) = "lineitem.l_partkey"(#3.1)
+                        ├── (.output_columns): [ "lineitem.l_partkey"(#3.1), "lineitem.l_quantity"(#3.4) ]
+                        ├── (.cardinality): 0.00
+                        └── Get
+                            ├── .data_source_id: 8
+                            ├── .table_index: 3
+                            ├── .implementation: None
+                            ├── (.output_columns): [ "lineitem.l_partkey"(#3.1), "lineitem.l_quantity"(#3.4) ]
+                            └── (.cardinality): 0.00
+
+NULL
 */
 

--- a/tests/sqlplannertest/tests/tpch/q18.planner.sql
+++ b/tests/sqlplannertest/tests/tpch/q18.planner.sql
@@ -34,7 +34,444 @@ order by
 limit 100;
 
 /*
-Error
-Schema error: No field named "__#7".l_orderkey. Did you mean 'orders.o_orderkey'?.
+logical_plan after optd-initial:
+Limit
+├── .skip: 0::bigint
+├── .fetch: 100::bigint
+├── (.output_columns):
+│   ┌── "__#10.c_custkey"(#10.1)
+│   ├── "__#10.c_name"(#10.0)
+│   ├── "__#10.o_orderdate"(#10.3)
+│   ├── "__#10.o_orderkey"(#10.2)
+│   ├── "__#10.o_totalprice"(#10.4)
+│   └── "__#10.sum(lineitem.l_quantity)"(#10.5)
+├── (.cardinality): 0.00
+└── OrderBy
+    ├── ordering_exprs: [ "__#10.o_totalprice"(#10.4) DESC, "__#10.o_orderdate"(#10.3) ASC ]
+    ├── (.output_columns):
+    │   ┌── "__#10.c_custkey"(#10.1)
+    │   ├── "__#10.c_name"(#10.0)
+    │   ├── "__#10.o_orderdate"(#10.3)
+    │   ├── "__#10.o_orderkey"(#10.2)
+    │   ├── "__#10.o_totalprice"(#10.4)
+    │   └── "__#10.sum(lineitem.l_quantity)"(#10.5)
+    ├── (.cardinality): 0.00
+    └── Project
+        ├── .table_index: 10
+        ├── .projections:
+        │   ┌── "customer.c_name"(#1.1)
+        │   ├── "customer.c_custkey"(#1.0)
+        │   ├── "orders.o_orderkey"(#2.0)
+        │   ├── "orders.o_orderdate"(#2.4)
+        │   ├── "orders.o_totalprice"(#2.3)
+        │   └── "__#9.sum(lineitem.l_quantity)"(#9.0)
+        ├── (.output_columns):
+        │   ┌── "__#10.c_custkey"(#10.1)
+        │   ├── "__#10.c_name"(#10.0)
+        │   ├── "__#10.o_orderdate"(#10.3)
+        │   ├── "__#10.o_orderkey"(#10.2)
+        │   ├── "__#10.o_totalprice"(#10.4)
+        │   └── "__#10.sum(lineitem.l_quantity)"(#10.5)
+        ├── (.cardinality): 0.00
+        └── Aggregate
+            ├── .key_table_index: 8
+            ├── .aggregate_table_index: 9
+            ├── .implementation: None
+            ├── .exprs: sum("lineitem.l_quantity"(#3.4))
+            ├── .keys:
+            │   ┌── "customer.c_name"(#1.1)
+            │   ├── "customer.c_custkey"(#1.0)
+            │   ├── "orders.o_orderkey"(#2.0)
+            │   ├── "orders.o_orderdate"(#2.4)
+            │   └── "orders.o_totalprice"(#2.3)
+            ├── (.output_columns):
+            │   ┌── "__#8.c_custkey"(#8.1)
+            │   ├── "__#8.c_name"(#8.0)
+            │   ├── "__#8.o_orderdate"(#8.3)
+            │   ├── "__#8.o_orderkey"(#8.2)
+            │   ├── "__#8.o_totalprice"(#8.4)
+            │   └── "__#9.sum(lineitem.l_quantity)"(#9.0)
+            ├── (.cardinality): 0.00
+            └── Select
+                ├── .predicate: ("customer.c_custkey"(#1.0) = "orders.o_custkey"(#2.1)) AND ("orders.o_orderkey"(#2.0) = "lineitem.l_orderkey"(#3.0))
+                ├── (.output_columns):
+                │   ┌── "customer.c_acctbal"(#1.5)
+                │   ├── "customer.c_address"(#1.2)
+                │   ├── "customer.c_comment"(#1.7)
+                │   ├── "customer.c_custkey"(#1.0)
+                │   ├── "customer.c_mktsegment"(#1.6)
+                │   ├── "customer.c_name"(#1.1)
+                │   ├── "customer.c_nationkey"(#1.3)
+                │   ├── "customer.c_phone"(#1.4)
+                │   ├── "lineitem.l_comment"(#3.15)
+                │   ├── "lineitem.l_commitdate"(#3.11)
+                │   ├── "lineitem.l_discount"(#3.6)
+                │   ├── "lineitem.l_extendedprice"(#3.5)
+                │   ├── "lineitem.l_linenumber"(#3.3)
+                │   ├── "lineitem.l_linestatus"(#3.9)
+                │   ├── "lineitem.l_orderkey"(#3.0)
+                │   ├── "lineitem.l_partkey"(#3.1)
+                │   ├── "lineitem.l_quantity"(#3.4)
+                │   ├── "lineitem.l_receiptdate"(#3.12)
+                │   ├── "lineitem.l_returnflag"(#3.8)
+                │   ├── "lineitem.l_shipdate"(#3.10)
+                │   ├── "lineitem.l_shipinstruct"(#3.13)
+                │   ├── "lineitem.l_shipmode"(#3.14)
+                │   ├── "lineitem.l_suppkey"(#3.2)
+                │   ├── "lineitem.l_tax"(#3.7)
+                │   ├── "orders.o_clerk"(#2.6)
+                │   ├── "orders.o_comment"(#2.8)
+                │   ├── "orders.o_custkey"(#2.1)
+                │   ├── "orders.o_orderdate"(#2.4)
+                │   ├── "orders.o_orderkey"(#2.0)
+                │   ├── "orders.o_orderpriority"(#2.5)
+                │   ├── "orders.o_orderstatus"(#2.2)
+                │   ├── "orders.o_shippriority"(#2.7)
+                │   └── "orders.o_totalprice"(#2.3)
+                ├── (.cardinality): 0.00
+                └── DependentJoin
+                    ├── .join_type: LeftSemi
+                    ├── .join_cond: "orders.o_orderkey"(#2.0) = "__#7.l_orderkey"(#7.0)
+                    ├── (.output_columns):
+                    │   ┌── "customer.c_acctbal"(#1.5)
+                    │   ├── "customer.c_address"(#1.2)
+                    │   ├── "customer.c_comment"(#1.7)
+                    │   ├── "customer.c_custkey"(#1.0)
+                    │   ├── "customer.c_mktsegment"(#1.6)
+                    │   ├── "customer.c_name"(#1.1)
+                    │   ├── "customer.c_nationkey"(#1.3)
+                    │   ├── "customer.c_phone"(#1.4)
+                    │   ├── "lineitem.l_comment"(#3.15)
+                    │   ├── "lineitem.l_commitdate"(#3.11)
+                    │   ├── "lineitem.l_discount"(#3.6)
+                    │   ├── "lineitem.l_extendedprice"(#3.5)
+                    │   ├── "lineitem.l_linenumber"(#3.3)
+                    │   ├── "lineitem.l_linestatus"(#3.9)
+                    │   ├── "lineitem.l_orderkey"(#3.0)
+                    │   ├── "lineitem.l_partkey"(#3.1)
+                    │   ├── "lineitem.l_quantity"(#3.4)
+                    │   ├── "lineitem.l_receiptdate"(#3.12)
+                    │   ├── "lineitem.l_returnflag"(#3.8)
+                    │   ├── "lineitem.l_shipdate"(#3.10)
+                    │   ├── "lineitem.l_shipinstruct"(#3.13)
+                    │   ├── "lineitem.l_shipmode"(#3.14)
+                    │   ├── "lineitem.l_suppkey"(#3.2)
+                    │   ├── "lineitem.l_tax"(#3.7)
+                    │   ├── "orders.o_clerk"(#2.6)
+                    │   ├── "orders.o_comment"(#2.8)
+                    │   ├── "orders.o_custkey"(#2.1)
+                    │   ├── "orders.o_orderdate"(#2.4)
+                    │   ├── "orders.o_orderkey"(#2.0)
+                    │   ├── "orders.o_orderpriority"(#2.5)
+                    │   ├── "orders.o_orderstatus"(#2.2)
+                    │   ├── "orders.o_shippriority"(#2.7)
+                    │   └── "orders.o_totalprice"(#2.3)
+                    ├── (.cardinality): 0.00
+                    ├── Join
+                    │   ├── .join_type: Inner
+                    │   ├── .implementation: None
+                    │   ├── .join_cond: 
+                    │   ├── (.output_columns):
+                    │   │   ┌── "customer.c_acctbal"(#1.5)
+                    │   │   ├── "customer.c_address"(#1.2)
+                    │   │   ├── "customer.c_comment"(#1.7)
+                    │   │   ├── "customer.c_custkey"(#1.0)
+                    │   │   ├── "customer.c_mktsegment"(#1.6)
+                    │   │   ├── "customer.c_name"(#1.1)
+                    │   │   ├── "customer.c_nationkey"(#1.3)
+                    │   │   ├── "customer.c_phone"(#1.4)
+                    │   │   ├── "lineitem.l_comment"(#3.15)
+                    │   │   ├── "lineitem.l_commitdate"(#3.11)
+                    │   │   ├── "lineitem.l_discount"(#3.6)
+                    │   │   ├── "lineitem.l_extendedprice"(#3.5)
+                    │   │   ├── "lineitem.l_linenumber"(#3.3)
+                    │   │   ├── "lineitem.l_linestatus"(#3.9)
+                    │   │   ├── "lineitem.l_orderkey"(#3.0)
+                    │   │   ├── "lineitem.l_partkey"(#3.1)
+                    │   │   ├── "lineitem.l_quantity"(#3.4)
+                    │   │   ├── "lineitem.l_receiptdate"(#3.12)
+                    │   │   ├── "lineitem.l_returnflag"(#3.8)
+                    │   │   ├── "lineitem.l_shipdate"(#3.10)
+                    │   │   ├── "lineitem.l_shipinstruct"(#3.13)
+                    │   │   ├── "lineitem.l_shipmode"(#3.14)
+                    │   │   ├── "lineitem.l_suppkey"(#3.2)
+                    │   │   ├── "lineitem.l_tax"(#3.7)
+                    │   │   ├── "orders.o_clerk"(#2.6)
+                    │   │   ├── "orders.o_comment"(#2.8)
+                    │   │   ├── "orders.o_custkey"(#2.1)
+                    │   │   ├── "orders.o_orderdate"(#2.4)
+                    │   │   ├── "orders.o_orderkey"(#2.0)
+                    │   │   ├── "orders.o_orderpriority"(#2.5)
+                    │   │   ├── "orders.o_orderstatus"(#2.2)
+                    │   │   ├── "orders.o_shippriority"(#2.7)
+                    │   │   └── "orders.o_totalprice"(#2.3)
+                    │   ├── (.cardinality): 0.00
+                    │   ├── Join
+                    │   │   ├── .join_type: Inner
+                    │   │   ├── .implementation: None
+                    │   │   ├── .join_cond: 
+                    │   │   ├── (.output_columns):
+                    │   │   │   ┌── "customer.c_acctbal"(#1.5)
+                    │   │   │   ├── "customer.c_address"(#1.2)
+                    │   │   │   ├── "customer.c_comment"(#1.7)
+                    │   │   │   ├── "customer.c_custkey"(#1.0)
+                    │   │   │   ├── "customer.c_mktsegment"(#1.6)
+                    │   │   │   ├── "customer.c_name"(#1.1)
+                    │   │   │   ├── "customer.c_nationkey"(#1.3)
+                    │   │   │   ├── "customer.c_phone"(#1.4)
+                    │   │   │   ├── "orders.o_clerk"(#2.6)
+                    │   │   │   ├── "orders.o_comment"(#2.8)
+                    │   │   │   ├── "orders.o_custkey"(#2.1)
+                    │   │   │   ├── "orders.o_orderdate"(#2.4)
+                    │   │   │   ├── "orders.o_orderkey"(#2.0)
+                    │   │   │   ├── "orders.o_orderpriority"(#2.5)
+                    │   │   │   ├── "orders.o_orderstatus"(#2.2)
+                    │   │   │   ├── "orders.o_shippriority"(#2.7)
+                    │   │   │   └── "orders.o_totalprice"(#2.3)
+                    │   │   ├── (.cardinality): 0.00
+                    │   │   ├── Get
+                    │   │   │   ├── .data_source_id: 6
+                    │   │   │   ├── .table_index: 1
+                    │   │   │   ├── .implementation: None
+                    │   │   │   ├── (.output_columns):
+                    │   │   │   │   ┌── "customer.c_acctbal"(#1.5)
+                    │   │   │   │   ├── "customer.c_address"(#1.2)
+                    │   │   │   │   ├── "customer.c_comment"(#1.7)
+                    │   │   │   │   ├── "customer.c_custkey"(#1.0)
+                    │   │   │   │   ├── "customer.c_mktsegment"(#1.6)
+                    │   │   │   │   ├── "customer.c_name"(#1.1)
+                    │   │   │   │   ├── "customer.c_nationkey"(#1.3)
+                    │   │   │   │   └── "customer.c_phone"(#1.4)
+                    │   │   │   └── (.cardinality): 0.00
+                    │   │   └── Get
+                    │   │       ├── .data_source_id: 7
+                    │   │       ├── .table_index: 2
+                    │   │       ├── .implementation: None
+                    │   │       ├── (.output_columns):
+                    │   │       │   ┌── "orders.o_clerk"(#2.6)
+                    │   │       │   ├── "orders.o_comment"(#2.8)
+                    │   │       │   ├── "orders.o_custkey"(#2.1)
+                    │   │       │   ├── "orders.o_orderdate"(#2.4)
+                    │   │       │   ├── "orders.o_orderkey"(#2.0)
+                    │   │       │   ├── "orders.o_orderpriority"(#2.5)
+                    │   │       │   ├── "orders.o_orderstatus"(#2.2)
+                    │   │       │   ├── "orders.o_shippriority"(#2.7)
+                    │   │       │   └── "orders.o_totalprice"(#2.3)
+                    │   │       └── (.cardinality): 0.00
+                    │   └── Get
+                    │       ├── .data_source_id: 8
+                    │       ├── .table_index: 3
+                    │       ├── .implementation: None
+                    │       ├── (.output_columns):
+                    │       │   ┌── "lineitem.l_comment"(#3.15)
+                    │       │   ├── "lineitem.l_commitdate"(#3.11)
+                    │       │   ├── "lineitem.l_discount"(#3.6)
+                    │       │   ├── "lineitem.l_extendedprice"(#3.5)
+                    │       │   ├── "lineitem.l_linenumber"(#3.3)
+                    │       │   ├── "lineitem.l_linestatus"(#3.9)
+                    │       │   ├── "lineitem.l_orderkey"(#3.0)
+                    │       │   ├── "lineitem.l_partkey"(#3.1)
+                    │       │   ├── "lineitem.l_quantity"(#3.4)
+                    │       │   ├── "lineitem.l_receiptdate"(#3.12)
+                    │       │   ├── "lineitem.l_returnflag"(#3.8)
+                    │       │   ├── "lineitem.l_shipdate"(#3.10)
+                    │       │   ├── "lineitem.l_shipinstruct"(#3.13)
+                    │       │   ├── "lineitem.l_shipmode"(#3.14)
+                    │       │   ├── "lineitem.l_suppkey"(#3.2)
+                    │       │   └── "lineitem.l_tax"(#3.7)
+                    │       └── (.cardinality): 0.00
+                    └── Project
+                        ├── .table_index: 7
+                        ├── .projections: "lineitem.l_orderkey"(#4.0)
+                        ├── (.output_columns): "__#7.l_orderkey"(#7.0)
+                        ├── (.cardinality): 0.00
+                        └── Select
+                            ├── .predicate: "__#6.sum(lineitem.l_quantity)"(#6.0) > CAST (250::bigint AS Decimal128(25, 2))
+                            ├── (.output_columns): [ "__#5.l_orderkey"(#5.0), "__#6.sum(lineitem.l_quantity)"(#6.0) ]
+                            ├── (.cardinality): 0.00
+                            └── Aggregate
+                                ├── .key_table_index: 5
+                                ├── .aggregate_table_index: 6
+                                ├── .implementation: None
+                                ├── .exprs: sum("lineitem.l_quantity"(#4.4))
+                                ├── .keys: "lineitem.l_orderkey"(#4.0)
+                                ├── (.output_columns): [ "__#5.l_orderkey"(#5.0), "__#6.sum(lineitem.l_quantity)"(#6.0) ]
+                                ├── (.cardinality): 0.00
+                                └── Get
+                                    ├── .data_source_id: 8
+                                    ├── .table_index: 4
+                                    ├── .implementation: None
+                                    ├── (.output_columns):
+                                    │   ┌── "lineitem.l_comment"(#4.15)
+                                    │   ├── "lineitem.l_commitdate"(#4.11)
+                                    │   ├── "lineitem.l_discount"(#4.6)
+                                    │   ├── "lineitem.l_extendedprice"(#4.5)
+                                    │   ├── "lineitem.l_linenumber"(#4.3)
+                                    │   ├── "lineitem.l_linestatus"(#4.9)
+                                    │   ├── "lineitem.l_orderkey"(#4.0)
+                                    │   ├── "lineitem.l_partkey"(#4.1)
+                                    │   ├── "lineitem.l_quantity"(#4.4)
+                                    │   ├── "lineitem.l_receiptdate"(#4.12)
+                                    │   ├── "lineitem.l_returnflag"(#4.8)
+                                    │   ├── "lineitem.l_shipdate"(#4.10)
+                                    │   ├── "lineitem.l_shipinstruct"(#4.13)
+                                    │   ├── "lineitem.l_shipmode"(#4.14)
+                                    │   ├── "lineitem.l_suppkey"(#4.2)
+                                    │   └── "lineitem.l_tax"(#4.7)
+                                    └── (.cardinality): 0.00
+
+physical_plan after optd-finalized:
+Limit
+├── .skip: 0::bigint
+├── .fetch: 100::bigint
+├── (.output_columns):
+│   ┌── "__#10.c_custkey"(#10.1)
+│   ├── "__#10.c_name"(#10.0)
+│   ├── "__#10.o_orderdate"(#10.3)
+│   ├── "__#10.o_orderkey"(#10.2)
+│   ├── "__#10.o_totalprice"(#10.4)
+│   └── "__#10.sum(lineitem.l_quantity)"(#10.5)
+├── (.cardinality): 0.00
+└── EnforcerSort
+    ├── tuple_ordering: [(#10.4, Desc), (#10.3, Asc)]
+    ├── (.output_columns):
+    │   ┌── "__#10.c_custkey"(#10.1)
+    │   ├── "__#10.c_name"(#10.0)
+    │   ├── "__#10.o_orderdate"(#10.3)
+    │   ├── "__#10.o_orderkey"(#10.2)
+    │   ├── "__#10.o_totalprice"(#10.4)
+    │   └── "__#10.sum(lineitem.l_quantity)"(#10.5)
+    ├── (.cardinality): 0.00
+    └── Project
+        ├── .table_index: 10
+        ├── .projections:
+        │   ┌── "customer.c_name"(#1.1)
+        │   ├── "customer.c_custkey"(#1.0)
+        │   ├── "orders.o_orderkey"(#2.0)
+        │   ├── "orders.o_orderdate"(#2.4)
+        │   ├── "orders.o_totalprice"(#2.3)
+        │   └── "__#9.sum(lineitem.l_quantity)"(#9.0)
+        ├── (.output_columns):
+        │   ┌── "__#10.c_custkey"(#10.1)
+        │   ├── "__#10.c_name"(#10.0)
+        │   ├── "__#10.o_orderdate"(#10.3)
+        │   ├── "__#10.o_orderkey"(#10.2)
+        │   ├── "__#10.o_totalprice"(#10.4)
+        │   └── "__#10.sum(lineitem.l_quantity)"(#10.5)
+        ├── (.cardinality): 0.00
+        └── Aggregate
+            ├── .key_table_index: 8
+            ├── .aggregate_table_index: 9
+            ├── .implementation: None
+            ├── .exprs: sum("lineitem.l_quantity"(#3.4))
+            ├── .keys:
+            │   ┌── "customer.c_name"(#1.1)
+            │   ├── "customer.c_custkey"(#1.0)
+            │   ├── "orders.o_orderkey"(#2.0)
+            │   ├── "orders.o_orderdate"(#2.4)
+            │   └── "orders.o_totalprice"(#2.3)
+            ├── (.output_columns):
+            │   ┌── "__#8.c_custkey"(#8.1)
+            │   ├── "__#8.c_name"(#8.0)
+            │   ├── "__#8.o_orderdate"(#8.3)
+            │   ├── "__#8.o_orderkey"(#8.2)
+            │   ├── "__#8.o_totalprice"(#8.4)
+            │   └── "__#9.sum(lineitem.l_quantity)"(#9.0)
+            ├── (.cardinality): 0.00
+            └── Join
+                ├── .join_type: LeftSemi
+                ├── .implementation: None
+                ├── .join_cond: "orders.o_orderkey"(#2.0) = "__#13.l_orderkey"(#13.0)
+                ├── (.output_columns):
+                │   ┌── "customer.c_custkey"(#1.0)
+                │   ├── "customer.c_name"(#1.1)
+                │   ├── "lineitem.l_orderkey"(#3.0)
+                │   ├── "lineitem.l_quantity"(#3.4)
+                │   ├── "orders.o_custkey"(#2.1)
+                │   ├── "orders.o_orderdate"(#2.4)
+                │   ├── "orders.o_orderkey"(#2.0)
+                │   └── "orders.o_totalprice"(#2.3)
+                ├── (.cardinality): 0.00
+                ├── Join
+                │   ├── .join_type: Inner
+                │   ├── .implementation: None
+                │   ├── .join_cond: "orders.o_orderkey"(#2.0) = "lineitem.l_orderkey"(#3.0)
+                │   ├── (.output_columns):
+                │   │   ┌── "customer.c_custkey"(#1.0)
+                │   │   ├── "customer.c_name"(#1.1)
+                │   │   ├── "lineitem.l_orderkey"(#3.0)
+                │   │   ├── "lineitem.l_quantity"(#3.4)
+                │   │   ├── "orders.o_custkey"(#2.1)
+                │   │   ├── "orders.o_orderdate"(#2.4)
+                │   │   ├── "orders.o_orderkey"(#2.0)
+                │   │   └── "orders.o_totalprice"(#2.3)
+                │   ├── (.cardinality): 0.00
+                │   ├── Join
+                │   │   ├── .join_type: Inner
+                │   │   ├── .implementation: None
+                │   │   ├── .join_cond: "customer.c_custkey"(#1.0) = "orders.o_custkey"(#2.1)
+                │   │   ├── (.output_columns):
+                │   │   │   ┌── "customer.c_custkey"(#1.0)
+                │   │   │   ├── "customer.c_name"(#1.1)
+                │   │   │   ├── "orders.o_custkey"(#2.1)
+                │   │   │   ├── "orders.o_orderdate"(#2.4)
+                │   │   │   ├── "orders.o_orderkey"(#2.0)
+                │   │   │   └── "orders.o_totalprice"(#2.3)
+                │   │   ├── (.cardinality): 0.00
+                │   │   ├── Get
+                │   │   │   ├── .data_source_id: 6
+                │   │   │   ├── .table_index: 1
+                │   │   │   ├── .implementation: None
+                │   │   │   ├── (.output_columns):
+                │   │   │   │   ┌── "customer.c_custkey"(#1.0)
+                │   │   │   │   └── "customer.c_name"(#1.1)
+                │   │   │   └── (.cardinality): 0.00
+                │   │   └── Get
+                │   │       ├── .data_source_id: 7
+                │   │       ├── .table_index: 2
+                │   │       ├── .implementation: None
+                │   │       ├── (.output_columns):
+                │   │       │   ┌── "orders.o_custkey"(#2.1)
+                │   │       │   ├── "orders.o_orderdate"(#2.4)
+                │   │       │   ├── "orders.o_orderkey"(#2.0)
+                │   │       │   └── "orders.o_totalprice"(#2.3)
+                │   │       └── (.cardinality): 0.00
+                │   └── Get
+                │       ├── .data_source_id: 8
+                │       ├── .table_index: 3
+                │       ├── .implementation: None
+                │       ├── (.output_columns):
+                │       │   ┌── "lineitem.l_orderkey"(#3.0)
+                │       │   └── "lineitem.l_quantity"(#3.4)
+                │       └── (.cardinality): 0.00
+                └── Project
+                    ├── .table_index: 13
+                    ├── .projections: "lineitem.l_orderkey"(#4.0)
+                    ├── (.output_columns): "__#13.l_orderkey"(#13.0)
+                    ├── (.cardinality): 0.00
+                    └── Select
+                        ├── .predicate: "__#6.sum(lineitem.l_quantity)"(#6.0) > 25000::decimal128(25, 2)
+                        ├── (.output_columns):
+                        │   ┌── "__#5.l_orderkey"(#5.0)
+                        │   └── "__#6.sum(lineitem.l_quantity)"(#6.0)
+                        ├── (.cardinality): 0.00
+                        └── Aggregate
+                            ├── .key_table_index: 5
+                            ├── .aggregate_table_index: 6
+                            ├── .implementation: None
+                            ├── .exprs: sum("lineitem.l_quantity"(#4.4))
+                            ├── .keys: "lineitem.l_orderkey"(#4.0)
+                            ├── (.output_columns):
+                            │   ┌── "__#5.l_orderkey"(#5.0)
+                            │   └── "__#6.sum(lineitem.l_quantity)"(#6.0)
+                            ├── (.cardinality): 0.00
+                            └── Get
+                                ├── .data_source_id: 8
+                                ├── .table_index: 4
+                                ├── .implementation: None
+                                ├── (.output_columns):
+                                │   ┌── "lineitem.l_orderkey"(#4.0)
+                                │   └── "lineitem.l_quantity"(#4.4)
+                                └── (.cardinality): 0.00
 */
 

--- a/tests/sqlplannertest/tests/tpch/q2.planner.sql
+++ b/tests/sqlplannertest/tests/tpch/q2.planner.sql
@@ -45,7 +45,677 @@ order by
 limit 100;
 
 /*
-Error
-Schema error: No field named "__#11"."min(partsupp.ps_supplycost)". Valid fields are part.p_partkey, partsupp.ps_partkey, "__#17".min.
+logical_plan after optd-initial:
+Limit { .skip: 0::bigint, .fetch: 100::bigint, (.output_columns): [ "__#13.n_name"(#13.2), "__#13.p_mfgr"(#13.4), "__#13.p_partkey"(#13.3), "__#13.s_acctbal"(#13.0), "__#13.s_address"(#13.5), "__#13.s_comment"(#13.7), "__#13.s_name"(#13.1), "__#13.s_phone"(#13.6) ], (.cardinality): 0.00 }
+└── OrderBy { ordering_exprs: [ "__#13.s_acctbal"(#13.0) DESC, "__#13.n_name"(#13.2) ASC, "__#13.s_name"(#13.1) ASC, "__#13.p_partkey"(#13.3) ASC ], (.output_columns): [ "__#13.n_name"(#13.2), "__#13.p_mfgr"(#13.4), "__#13.p_partkey"(#13.3), "__#13.s_acctbal"(#13.0), "__#13.s_address"(#13.5), "__#13.s_comment"(#13.7), "__#13.s_name"(#13.1), "__#13.s_phone"(#13.6) ], (.cardinality): 0.00 }
+    └── Project
+        ├── .table_index: 13
+        ├── .projections: [ "supplier.s_acctbal"(#2.5), "supplier.s_name"(#2.1), "nation.n_name"(#4.1), "part.p_partkey"(#1.0), "part.p_mfgr"(#1.2), "supplier.s_address"(#2.2), "supplier.s_phone"(#2.4), "supplier.s_comment"(#2.6) ]
+        ├── (.output_columns): [ "__#13.n_name"(#13.2), "__#13.p_mfgr"(#13.4), "__#13.p_partkey"(#13.3), "__#13.s_acctbal"(#13.0), "__#13.s_address"(#13.5), "__#13.s_comment"(#13.7), "__#13.s_name"(#13.1), "__#13.s_phone"(#13.6) ]
+        ├── (.cardinality): 0.00
+        └── DependentJoin
+            ├── .join_type: Inner
+            ├── .join_cond: "partsupp.ps_supplycost"(#3.3) = "__#12.min(partsupp.ps_supplycost)"(#12.0)
+            ├── (.output_columns):
+            │   ┌── "__#12.min(partsupp.ps_supplycost)"(#12.0)
+            │   ├── "nation.n_comment"(#4.3)
+            │   ├── "nation.n_name"(#4.1)
+            │   ├── "nation.n_nationkey"(#4.0)
+            │   ├── "nation.n_regionkey"(#4.2)
+            │   ├── "part.p_brand"(#1.3)
+            │   ├── "part.p_comment"(#1.8)
+            │   ├── "part.p_container"(#1.6)
+            │   ├── "part.p_mfgr"(#1.2)
+            │   ├── "part.p_name"(#1.1)
+            │   ├── "part.p_partkey"(#1.0)
+            │   ├── "part.p_retailprice"(#1.7)
+            │   ├── "part.p_size"(#1.5)
+            │   ├── "part.p_type"(#1.4)
+            │   ├── "partsupp.ps_availqty"(#3.2)
+            │   ├── "partsupp.ps_comment"(#3.4)
+            │   ├── "partsupp.ps_partkey"(#3.0)
+            │   ├── "partsupp.ps_suppkey"(#3.1)
+            │   ├── "partsupp.ps_supplycost"(#3.3)
+            │   ├── "region.r_comment"(#5.2)
+            │   ├── "region.r_name"(#5.1)
+            │   ├── "region.r_regionkey"(#5.0)
+            │   ├── "supplier.s_acctbal"(#2.5)
+            │   ├── "supplier.s_address"(#2.2)
+            │   ├── "supplier.s_comment"(#2.6)
+            │   ├── "supplier.s_name"(#2.1)
+            │   ├── "supplier.s_nationkey"(#2.3)
+            │   ├── "supplier.s_phone"(#2.4)
+            │   └── "supplier.s_suppkey"(#2.0)
+            ├── (.cardinality): 0.00
+            ├── Select
+            │   ├── .predicate: ("part.p_partkey"(#1.0) = "partsupp.ps_partkey"(#3.0)) AND ("supplier.s_suppkey"(#2.0) = "partsupp.ps_suppkey"(#3.1)) AND (CAST ("part.p_size"(#1.5) AS Int64) = 4::bigint) AND ("part.p_type"(#1.4) LIKE CAST ('%TIN'::utf8 AS Utf8View)) AND ("supplier.s_nationkey"(#2.3) = "nation.n_nationkey"(#4.0)) AND ("nation.n_regionkey"(#4.2) = "region.r_regionkey"(#5.0)) AND ("region.r_name"(#5.1) = CAST ('AFRICA'::utf8 AS Utf8View))
+            │   ├── (.output_columns):
+            │   │   ┌── "nation.n_comment"(#4.3)
+            │   │   ├── "nation.n_name"(#4.1)
+            │   │   ├── "nation.n_nationkey"(#4.0)
+            │   │   ├── "nation.n_regionkey"(#4.2)
+            │   │   ├── "part.p_brand"(#1.3)
+            │   │   ├── "part.p_comment"(#1.8)
+            │   │   ├── "part.p_container"(#1.6)
+            │   │   ├── "part.p_mfgr"(#1.2)
+            │   │   ├── "part.p_name"(#1.1)
+            │   │   ├── "part.p_partkey"(#1.0)
+            │   │   ├── "part.p_retailprice"(#1.7)
+            │   │   ├── "part.p_size"(#1.5)
+            │   │   ├── "part.p_type"(#1.4)
+            │   │   ├── "partsupp.ps_availqty"(#3.2)
+            │   │   ├── "partsupp.ps_comment"(#3.4)
+            │   │   ├── "partsupp.ps_partkey"(#3.0)
+            │   │   ├── "partsupp.ps_suppkey"(#3.1)
+            │   │   ├── "partsupp.ps_supplycost"(#3.3)
+            │   │   ├── "region.r_comment"(#5.2)
+            │   │   ├── "region.r_name"(#5.1)
+            │   │   ├── "region.r_regionkey"(#5.0)
+            │   │   ├── "supplier.s_acctbal"(#2.5)
+            │   │   ├── "supplier.s_address"(#2.2)
+            │   │   ├── "supplier.s_comment"(#2.6)
+            │   │   ├── "supplier.s_name"(#2.1)
+            │   │   ├── "supplier.s_nationkey"(#2.3)
+            │   │   ├── "supplier.s_phone"(#2.4)
+            │   │   └── "supplier.s_suppkey"(#2.0)
+            │   ├── (.cardinality): 0.00
+            │   └── Join
+            │       ├── .join_type: Inner
+            │       ├── .implementation: None
+            │       ├── .join_cond: 
+            │       ├── (.output_columns):
+            │       │   ┌── "nation.n_comment"(#4.3)
+            │       │   ├── "nation.n_name"(#4.1)
+            │       │   ├── "nation.n_nationkey"(#4.0)
+            │       │   ├── "nation.n_regionkey"(#4.2)
+            │       │   ├── "part.p_brand"(#1.3)
+            │       │   ├── "part.p_comment"(#1.8)
+            │       │   ├── "part.p_container"(#1.6)
+            │       │   ├── "part.p_mfgr"(#1.2)
+            │       │   ├── "part.p_name"(#1.1)
+            │       │   ├── "part.p_partkey"(#1.0)
+            │       │   ├── "part.p_retailprice"(#1.7)
+            │       │   ├── "part.p_size"(#1.5)
+            │       │   ├── "part.p_type"(#1.4)
+            │       │   ├── "partsupp.ps_availqty"(#3.2)
+            │       │   ├── "partsupp.ps_comment"(#3.4)
+            │       │   ├── "partsupp.ps_partkey"(#3.0)
+            │       │   ├── "partsupp.ps_suppkey"(#3.1)
+            │       │   ├── "partsupp.ps_supplycost"(#3.3)
+            │       │   ├── "region.r_comment"(#5.2)
+            │       │   ├── "region.r_name"(#5.1)
+            │       │   ├── "region.r_regionkey"(#5.0)
+            │       │   ├── "supplier.s_acctbal"(#2.5)
+            │       │   ├── "supplier.s_address"(#2.2)
+            │       │   ├── "supplier.s_comment"(#2.6)
+            │       │   ├── "supplier.s_name"(#2.1)
+            │       │   ├── "supplier.s_nationkey"(#2.3)
+            │       │   ├── "supplier.s_phone"(#2.4)
+            │       │   └── "supplier.s_suppkey"(#2.0)
+            │       ├── (.cardinality): 0.00
+            │       ├── Join
+            │       │   ├── .join_type: Inner
+            │       │   ├── .implementation: None
+            │       │   ├── .join_cond: 
+            │       │   ├── (.output_columns):
+            │       │   │   ┌── "nation.n_comment"(#4.3)
+            │       │   │   ├── "nation.n_name"(#4.1)
+            │       │   │   ├── "nation.n_nationkey"(#4.0)
+            │       │   │   ├── "nation.n_regionkey"(#4.2)
+            │       │   │   ├── "part.p_brand"(#1.3)
+            │       │   │   ├── "part.p_comment"(#1.8)
+            │       │   │   ├── "part.p_container"(#1.6)
+            │       │   │   ├── "part.p_mfgr"(#1.2)
+            │       │   │   ├── "part.p_name"(#1.1)
+            │       │   │   ├── "part.p_partkey"(#1.0)
+            │       │   │   ├── "part.p_retailprice"(#1.7)
+            │       │   │   ├── "part.p_size"(#1.5)
+            │       │   │   ├── "part.p_type"(#1.4)
+            │       │   │   ├── "partsupp.ps_availqty"(#3.2)
+            │       │   │   ├── "partsupp.ps_comment"(#3.4)
+            │       │   │   ├── "partsupp.ps_partkey"(#3.0)
+            │       │   │   ├── "partsupp.ps_suppkey"(#3.1)
+            │       │   │   ├── "partsupp.ps_supplycost"(#3.3)
+            │       │   │   ├── "supplier.s_acctbal"(#2.5)
+            │       │   │   ├── "supplier.s_address"(#2.2)
+            │       │   │   ├── "supplier.s_comment"(#2.6)
+            │       │   │   ├── "supplier.s_name"(#2.1)
+            │       │   │   ├── "supplier.s_nationkey"(#2.3)
+            │       │   │   ├── "supplier.s_phone"(#2.4)
+            │       │   │   └── "supplier.s_suppkey"(#2.0)
+            │       │   ├── (.cardinality): 0.00
+            │       │   ├── Join
+            │       │   │   ├── .join_type: Inner
+            │       │   │   ├── .implementation: None
+            │       │   │   ├── .join_cond: 
+            │       │   │   ├── (.output_columns):
+            │       │   │   │   ┌── "part.p_brand"(#1.3)
+            │       │   │   │   ├── "part.p_comment"(#1.8)
+            │       │   │   │   ├── "part.p_container"(#1.6)
+            │       │   │   │   ├── "part.p_mfgr"(#1.2)
+            │       │   │   │   ├── "part.p_name"(#1.1)
+            │       │   │   │   ├── "part.p_partkey"(#1.0)
+            │       │   │   │   ├── "part.p_retailprice"(#1.7)
+            │       │   │   │   ├── "part.p_size"(#1.5)
+            │       │   │   │   ├── "part.p_type"(#1.4)
+            │       │   │   │   ├── "partsupp.ps_availqty"(#3.2)
+            │       │   │   │   ├── "partsupp.ps_comment"(#3.4)
+            │       │   │   │   ├── "partsupp.ps_partkey"(#3.0)
+            │       │   │   │   ├── "partsupp.ps_suppkey"(#3.1)
+            │       │   │   │   ├── "partsupp.ps_supplycost"(#3.3)
+            │       │   │   │   ├── "supplier.s_acctbal"(#2.5)
+            │       │   │   │   ├── "supplier.s_address"(#2.2)
+            │       │   │   │   ├── "supplier.s_comment"(#2.6)
+            │       │   │   │   ├── "supplier.s_name"(#2.1)
+            │       │   │   │   ├── "supplier.s_nationkey"(#2.3)
+            │       │   │   │   ├── "supplier.s_phone"(#2.4)
+            │       │   │   │   └── "supplier.s_suppkey"(#2.0)
+            │       │   │   ├── (.cardinality): 0.00
+            │       │   │   ├── Join
+            │       │   │   │   ├── .join_type: Inner
+            │       │   │   │   ├── .implementation: None
+            │       │   │   │   ├── .join_cond: 
+            │       │   │   │   ├── (.output_columns):
+            │       │   │   │   │   ┌── "part.p_brand"(#1.3)
+            │       │   │   │   │   ├── "part.p_comment"(#1.8)
+            │       │   │   │   │   ├── "part.p_container"(#1.6)
+            │       │   │   │   │   ├── "part.p_mfgr"(#1.2)
+            │       │   │   │   │   ├── "part.p_name"(#1.1)
+            │       │   │   │   │   ├── "part.p_partkey"(#1.0)
+            │       │   │   │   │   ├── "part.p_retailprice"(#1.7)
+            │       │   │   │   │   ├── "part.p_size"(#1.5)
+            │       │   │   │   │   ├── "part.p_type"(#1.4)
+            │       │   │   │   │   ├── "supplier.s_acctbal"(#2.5)
+            │       │   │   │   │   ├── "supplier.s_address"(#2.2)
+            │       │   │   │   │   ├── "supplier.s_comment"(#2.6)
+            │       │   │   │   │   ├── "supplier.s_name"(#2.1)
+            │       │   │   │   │   ├── "supplier.s_nationkey"(#2.3)
+            │       │   │   │   │   ├── "supplier.s_phone"(#2.4)
+            │       │   │   │   │   └── "supplier.s_suppkey"(#2.0)
+            │       │   │   │   ├── (.cardinality): 0.00
+            │       │   │   │   ├── Get { .data_source_id: 3, .table_index: 1, .implementation: None, (.output_columns): [ "part.p_brand"(#1.3), "part.p_comment"(#1.8), "part.p_container"(#1.6), "part.p_mfgr"(#1.2), "part.p_name"(#1.1), "part.p_partkey"(#1.0), "part.p_retailprice"(#1.7), "part.p_size"(#1.5), "part.p_type"(#1.4) ], (.cardinality): 0.00 }
+            │       │   │   │   └── Get { .data_source_id: 4, .table_index: 2, .implementation: None, (.output_columns): [ "supplier.s_acctbal"(#2.5), "supplier.s_address"(#2.2), "supplier.s_comment"(#2.6), "supplier.s_name"(#2.1), "supplier.s_nationkey"(#2.3), "supplier.s_phone"(#2.4), "supplier.s_suppkey"(#2.0) ], (.cardinality): 0.00 }
+            │       │   │   └── Get { .data_source_id: 5, .table_index: 3, .implementation: None, (.output_columns): [ "partsupp.ps_availqty"(#3.2), "partsupp.ps_comment"(#3.4), "partsupp.ps_partkey"(#3.0), "partsupp.ps_suppkey"(#3.1), "partsupp.ps_supplycost"(#3.3) ], (.cardinality): 0.00 }
+            │       │   └── Get { .data_source_id: 1, .table_index: 4, .implementation: None, (.output_columns): [ "nation.n_comment"(#4.3), "nation.n_name"(#4.1), "nation.n_nationkey"(#4.0), "nation.n_regionkey"(#4.2) ], (.cardinality): 0.00 }
+            │       └── Get { .data_source_id: 2, .table_index: 5, .implementation: None, (.output_columns): [ "region.r_comment"(#5.2), "region.r_name"(#5.1), "region.r_regionkey"(#5.0) ], (.cardinality): 0.00 }
+            └── Project { .table_index: 12, .projections: "__#11.min(partsupp.ps_supplycost)"(#11.0), (.output_columns): "__#12.min(partsupp.ps_supplycost)"(#12.0), (.cardinality): 1.00 }
+                └── Aggregate { .key_table_index: 10, .aggregate_table_index: 11, .implementation: None, .exprs: min("partsupp.ps_supplycost"(#6.3)), .keys: [], (.output_columns): "__#11.min(partsupp.ps_supplycost)"(#11.0), (.cardinality): 1.00 }
+                    └── Select
+                        ├── .predicate: ("part.p_partkey"(#1.0) = "partsupp.ps_partkey"(#6.0)) AND ("supplier.s_suppkey"(#7.0) = "partsupp.ps_suppkey"(#6.1)) AND ("supplier.s_nationkey"(#7.3) = "nation.n_nationkey"(#8.0)) AND ("nation.n_regionkey"(#8.2) = "region.r_regionkey"(#9.0)) AND ("region.r_name"(#9.1) = CAST ('AFRICA'::utf8 AS Utf8View))
+                        ├── (.output_columns):
+                        │   ┌── "nation.n_comment"(#8.3)
+                        │   ├── "nation.n_name"(#8.1)
+                        │   ├── "nation.n_nationkey"(#8.0)
+                        │   ├── "nation.n_regionkey"(#8.2)
+                        │   ├── "partsupp.ps_availqty"(#6.2)
+                        │   ├── "partsupp.ps_comment"(#6.4)
+                        │   ├── "partsupp.ps_partkey"(#6.0)
+                        │   ├── "partsupp.ps_suppkey"(#6.1)
+                        │   ├── "partsupp.ps_supplycost"(#6.3)
+                        │   ├── "region.r_comment"(#9.2)
+                        │   ├── "region.r_name"(#9.1)
+                        │   ├── "region.r_regionkey"(#9.0)
+                        │   ├── "supplier.s_acctbal"(#7.5)
+                        │   ├── "supplier.s_address"(#7.2)
+                        │   ├── "supplier.s_comment"(#7.6)
+                        │   ├── "supplier.s_name"(#7.1)
+                        │   ├── "supplier.s_nationkey"(#7.3)
+                        │   ├── "supplier.s_phone"(#7.4)
+                        │   └── "supplier.s_suppkey"(#7.0)
+                        ├── (.cardinality): 0.00
+                        └── Join
+                            ├── .join_type: Inner
+                            ├── .implementation: None
+                            ├── .join_cond: 
+                            ├── (.output_columns):
+                            │   ┌── "nation.n_comment"(#8.3)
+                            │   ├── "nation.n_name"(#8.1)
+                            │   ├── "nation.n_nationkey"(#8.0)
+                            │   ├── "nation.n_regionkey"(#8.2)
+                            │   ├── "partsupp.ps_availqty"(#6.2)
+                            │   ├── "partsupp.ps_comment"(#6.4)
+                            │   ├── "partsupp.ps_partkey"(#6.0)
+                            │   ├── "partsupp.ps_suppkey"(#6.1)
+                            │   ├── "partsupp.ps_supplycost"(#6.3)
+                            │   ├── "region.r_comment"(#9.2)
+                            │   ├── "region.r_name"(#9.1)
+                            │   ├── "region.r_regionkey"(#9.0)
+                            │   ├── "supplier.s_acctbal"(#7.5)
+                            │   ├── "supplier.s_address"(#7.2)
+                            │   ├── "supplier.s_comment"(#7.6)
+                            │   ├── "supplier.s_name"(#7.1)
+                            │   ├── "supplier.s_nationkey"(#7.3)
+                            │   ├── "supplier.s_phone"(#7.4)
+                            │   └── "supplier.s_suppkey"(#7.0)
+                            ├── (.cardinality): 0.00
+                            ├── Join
+                            │   ├── .join_type: Inner
+                            │   ├── .implementation: None
+                            │   ├── .join_cond: 
+                            │   ├── (.output_columns):
+                            │   │   ┌── "nation.n_comment"(#8.3)
+                            │   │   ├── "nation.n_name"(#8.1)
+                            │   │   ├── "nation.n_nationkey"(#8.0)
+                            │   │   ├── "nation.n_regionkey"(#8.2)
+                            │   │   ├── "partsupp.ps_availqty"(#6.2)
+                            │   │   ├── "partsupp.ps_comment"(#6.4)
+                            │   │   ├── "partsupp.ps_partkey"(#6.0)
+                            │   │   ├── "partsupp.ps_suppkey"(#6.1)
+                            │   │   ├── "partsupp.ps_supplycost"(#6.3)
+                            │   │   ├── "supplier.s_acctbal"(#7.5)
+                            │   │   ├── "supplier.s_address"(#7.2)
+                            │   │   ├── "supplier.s_comment"(#7.6)
+                            │   │   ├── "supplier.s_name"(#7.1)
+                            │   │   ├── "supplier.s_nationkey"(#7.3)
+                            │   │   ├── "supplier.s_phone"(#7.4)
+                            │   │   └── "supplier.s_suppkey"(#7.0)
+                            │   ├── (.cardinality): 0.00
+                            │   ├── Join
+                            │   │   ├── .join_type: Inner
+                            │   │   ├── .implementation: None
+                            │   │   ├── .join_cond: 
+                            │   │   ├── (.output_columns): [ "partsupp.ps_availqty"(#6.2), "partsupp.ps_comment"(#6.4), "partsupp.ps_partkey"(#6.0), "partsupp.ps_suppkey"(#6.1), "partsupp.ps_supplycost"(#6.3), "supplier.s_acctbal"(#7.5), "supplier.s_address"(#7.2), "supplier.s_comment"(#7.6), "supplier.s_name"(#7.1), "supplier.s_nationkey"(#7.3), "supplier.s_phone"(#7.4), "supplier.s_suppkey"(#7.0) ]
+                            │   │   ├── (.cardinality): 0.00
+                            │   │   ├── Get { .data_source_id: 5, .table_index: 6, .implementation: None, (.output_columns): [ "partsupp.ps_availqty"(#6.2), "partsupp.ps_comment"(#6.4), "partsupp.ps_partkey"(#6.0), "partsupp.ps_suppkey"(#6.1), "partsupp.ps_supplycost"(#6.3) ], (.cardinality): 0.00 }
+                            │   │   └── Get { .data_source_id: 4, .table_index: 7, .implementation: None, (.output_columns): [ "supplier.s_acctbal"(#7.5), "supplier.s_address"(#7.2), "supplier.s_comment"(#7.6), "supplier.s_name"(#7.1), "supplier.s_nationkey"(#7.3), "supplier.s_phone"(#7.4), "supplier.s_suppkey"(#7.0) ], (.cardinality): 0.00 }
+                            │   └── Get { .data_source_id: 1, .table_index: 8, .implementation: None, (.output_columns): [ "nation.n_comment"(#8.3), "nation.n_name"(#8.1), "nation.n_nationkey"(#8.0), "nation.n_regionkey"(#8.2) ], (.cardinality): 0.00 }
+                            └── Get { .data_source_id: 2, .table_index: 9, .implementation: None, (.output_columns): [ "region.r_comment"(#9.2), "region.r_name"(#9.1), "region.r_regionkey"(#9.0) ], (.cardinality): 0.00 }
+
+physical_plan after optd-finalized:
+Limit
+├── .skip: 0::bigint
+├── .fetch: 100::bigint
+├── (.output_columns):
+│   ┌── "__#13.n_name"(#13.2)
+│   ├── "__#13.p_mfgr"(#13.4)
+│   ├── "__#13.p_partkey"(#13.3)
+│   ├── "__#13.s_acctbal"(#13.0)
+│   ├── "__#13.s_address"(#13.5)
+│   ├── "__#13.s_comment"(#13.7)
+│   ├── "__#13.s_name"(#13.1)
+│   └── "__#13.s_phone"(#13.6)
+├── (.cardinality): 0.00
+└── EnforcerSort
+    ├── tuple_ordering: [(#13.0, Desc), (#13.2, Asc), (#13.1, Asc), (#13.3, Asc)]
+    ├── (.output_columns):
+    │   ┌── "__#13.n_name"(#13.2)
+    │   ├── "__#13.p_mfgr"(#13.4)
+    │   ├── "__#13.p_partkey"(#13.3)
+    │   ├── "__#13.s_acctbal"(#13.0)
+    │   ├── "__#13.s_address"(#13.5)
+    │   ├── "__#13.s_comment"(#13.7)
+    │   ├── "__#13.s_name"(#13.1)
+    │   └── "__#13.s_phone"(#13.6)
+    ├── (.cardinality): 0.00
+    └── Project
+        ├── .table_index: 13
+        ├── .projections:
+        │   ┌── "supplier.s_acctbal"(#2.5)
+        │   ├── "supplier.s_name"(#2.1)
+        │   ├── "nation.n_name"(#4.1)
+        │   ├── "part.p_partkey"(#1.0)
+        │   ├── "part.p_mfgr"(#1.2)
+        │   ├── "supplier.s_address"(#2.2)
+        │   ├── "supplier.s_phone"(#2.4)
+        │   └── "supplier.s_comment"(#2.6)
+        ├── (.output_columns):
+        │   ┌── "__#13.n_name"(#13.2)
+        │   ├── "__#13.p_mfgr"(#13.4)
+        │   ├── "__#13.p_partkey"(#13.3)
+        │   ├── "__#13.s_acctbal"(#13.0)
+        │   ├── "__#13.s_address"(#13.5)
+        │   ├── "__#13.s_comment"(#13.7)
+        │   ├── "__#13.s_name"(#13.1)
+        │   └── "__#13.s_phone"(#13.6)
+        ├── (.cardinality): 0.00
+        └── Join
+            ├── .join_type: Inner
+            ├── .implementation: None
+            ├── .join_cond: ("part.p_partkey"(#1.0) IS NOT DISTINCT FROM "__#18.p_partkey"(#18.1)) AND ("partsupp.ps_supplycost"(#3.3) = "__#18.min"(#18.0))
+            ├── (.output_columns):
+            │   ┌── "__#18.min"(#18.0)
+            │   ├── "__#18.p_partkey"(#18.1)
+            │   ├── "nation.n_name"(#4.1)
+            │   ├── "nation.n_nationkey"(#4.0)
+            │   ├── "nation.n_regionkey"(#4.2)
+            │   ├── "part.p_mfgr"(#1.2)
+            │   ├── "part.p_partkey"(#1.0)
+            │   ├── "part.p_size"(#1.5)
+            │   ├── "part.p_type"(#1.4)
+            │   ├── "partsupp.ps_partkey"(#3.0)
+            │   ├── "partsupp.ps_suppkey"(#3.1)
+            │   ├── "partsupp.ps_supplycost"(#3.3)
+            │   ├── "region.r_name"(#5.1)
+            │   ├── "region.r_regionkey"(#5.0)
+            │   ├── "supplier.s_acctbal"(#2.5)
+            │   ├── "supplier.s_address"(#2.2)
+            │   ├── "supplier.s_comment"(#2.6)
+            │   ├── "supplier.s_name"(#2.1)
+            │   ├── "supplier.s_nationkey"(#2.3)
+            │   ├── "supplier.s_phone"(#2.4)
+            │   └── "supplier.s_suppkey"(#2.0)
+            ├── (.cardinality): 0.00
+            ├── Join
+            │   ├── .join_type: Inner
+            │   ├── .implementation: None
+            │   ├── .join_cond: "nation.n_regionkey"(#4.2) = "region.r_regionkey"(#5.0)
+            │   ├── (.output_columns):
+            │   │   ┌── "nation.n_name"(#4.1)
+            │   │   ├── "nation.n_nationkey"(#4.0)
+            │   │   ├── "nation.n_regionkey"(#4.2)
+            │   │   ├── "part.p_mfgr"(#1.2)
+            │   │   ├── "part.p_partkey"(#1.0)
+            │   │   ├── "part.p_size"(#1.5)
+            │   │   ├── "part.p_type"(#1.4)
+            │   │   ├── "partsupp.ps_partkey"(#3.0)
+            │   │   ├── "partsupp.ps_suppkey"(#3.1)
+            │   │   ├── "partsupp.ps_supplycost"(#3.3)
+            │   │   ├── "region.r_name"(#5.1)
+            │   │   ├── "region.r_regionkey"(#5.0)
+            │   │   ├── "supplier.s_acctbal"(#2.5)
+            │   │   ├── "supplier.s_address"(#2.2)
+            │   │   ├── "supplier.s_comment"(#2.6)
+            │   │   ├── "supplier.s_name"(#2.1)
+            │   │   ├── "supplier.s_nationkey"(#2.3)
+            │   │   ├── "supplier.s_phone"(#2.4)
+            │   │   └── "supplier.s_suppkey"(#2.0)
+            │   ├── (.cardinality): 0.00
+            │   ├── Join
+            │   │   ├── .join_type: Inner
+            │   │   ├── .implementation: None
+            │   │   ├── .join_cond: "supplier.s_nationkey"(#2.3) = "nation.n_nationkey"(#4.0)
+            │   │   ├── (.output_columns):
+            │   │   │   ┌── "nation.n_name"(#4.1)
+            │   │   │   ├── "nation.n_nationkey"(#4.0)
+            │   │   │   ├── "nation.n_regionkey"(#4.2)
+            │   │   │   ├── "part.p_mfgr"(#1.2)
+            │   │   │   ├── "part.p_partkey"(#1.0)
+            │   │   │   ├── "part.p_size"(#1.5)
+            │   │   │   ├── "part.p_type"(#1.4)
+            │   │   │   ├── "partsupp.ps_partkey"(#3.0)
+            │   │   │   ├── "partsupp.ps_suppkey"(#3.1)
+            │   │   │   ├── "partsupp.ps_supplycost"(#3.3)
+            │   │   │   ├── "supplier.s_acctbal"(#2.5)
+            │   │   │   ├── "supplier.s_address"(#2.2)
+            │   │   │   ├── "supplier.s_comment"(#2.6)
+            │   │   │   ├── "supplier.s_name"(#2.1)
+            │   │   │   ├── "supplier.s_nationkey"(#2.3)
+            │   │   │   ├── "supplier.s_phone"(#2.4)
+            │   │   │   └── "supplier.s_suppkey"(#2.0)
+            │   │   ├── (.cardinality): 0.00
+            │   │   ├── Join
+            │   │   │   ├── .join_type: Inner
+            │   │   │   ├── .implementation: None
+            │   │   │   ├── .join_cond: ("part.p_partkey"(#1.0) = "partsupp.ps_partkey"(#3.0)) AND ("supplier.s_suppkey"(#2.0) = "partsupp.ps_suppkey"(#3.1))
+            │   │   │   ├── (.output_columns):
+            │   │   │   │   ┌── "part.p_mfgr"(#1.2)
+            │   │   │   │   ├── "part.p_partkey"(#1.0)
+            │   │   │   │   ├── "part.p_size"(#1.5)
+            │   │   │   │   ├── "part.p_type"(#1.4)
+            │   │   │   │   ├── "partsupp.ps_partkey"(#3.0)
+            │   │   │   │   ├── "partsupp.ps_suppkey"(#3.1)
+            │   │   │   │   ├── "partsupp.ps_supplycost"(#3.3)
+            │   │   │   │   ├── "supplier.s_acctbal"(#2.5)
+            │   │   │   │   ├── "supplier.s_address"(#2.2)
+            │   │   │   │   ├── "supplier.s_comment"(#2.6)
+            │   │   │   │   ├── "supplier.s_name"(#2.1)
+            │   │   │   │   ├── "supplier.s_nationkey"(#2.3)
+            │   │   │   │   ├── "supplier.s_phone"(#2.4)
+            │   │   │   │   └── "supplier.s_suppkey"(#2.0)
+            │   │   │   ├── (.cardinality): 0.00
+            │   │   │   ├── Join
+            │   │   │   │   ├── .join_type: Inner
+            │   │   │   │   ├── .implementation: None
+            │   │   │   │   ├── .join_cond: true::boolean
+            │   │   │   │   ├── (.output_columns):
+            │   │   │   │   │   ┌── "part.p_mfgr"(#1.2)
+            │   │   │   │   │   ├── "part.p_partkey"(#1.0)
+            │   │   │   │   │   ├── "part.p_size"(#1.5)
+            │   │   │   │   │   ├── "part.p_type"(#1.4)
+            │   │   │   │   │   ├── "supplier.s_acctbal"(#2.5)
+            │   │   │   │   │   ├── "supplier.s_address"(#2.2)
+            │   │   │   │   │   ├── "supplier.s_comment"(#2.6)
+            │   │   │   │   │   ├── "supplier.s_name"(#2.1)
+            │   │   │   │   │   ├── "supplier.s_nationkey"(#2.3)
+            │   │   │   │   │   ├── "supplier.s_phone"(#2.4)
+            │   │   │   │   │   └── "supplier.s_suppkey"(#2.0)
+            │   │   │   │   ├── (.cardinality): 0.00
+            │   │   │   │   ├── Select
+            │   │   │   │   │   ├── .predicate: ("part.p_size"(#1.5) = 4::integer) AND ("part.p_type"(#1.4) LIKE '%TIN'::utf8_view)
+            │   │   │   │   │   ├── (.output_columns): [ "part.p_mfgr"(#1.2), "part.p_partkey"(#1.0), "part.p_size"(#1.5), "part.p_type"(#1.4) ]
+            │   │   │   │   │   ├── (.cardinality): 0.00
+            │   │   │   │   │   └── Get
+            │   │   │   │   │       ├── .data_source_id: 3
+            │   │   │   │   │       ├── .table_index: 1
+            │   │   │   │   │       ├── .implementation: None
+            │   │   │   │   │       ├── (.output_columns): [ "part.p_mfgr"(#1.2), "part.p_partkey"(#1.0), "part.p_size"(#1.5), "part.p_type"(#1.4) ]
+            │   │   │   │   │       └── (.cardinality): 0.00
+            │   │   │   │   └── Get
+            │   │   │   │       ├── .data_source_id: 4
+            │   │   │   │       ├── .table_index: 2
+            │   │   │   │       ├── .implementation: None
+            │   │   │   │       ├── (.output_columns):
+            │   │   │   │       │   ┌── "supplier.s_acctbal"(#2.5)
+            │   │   │   │       │   ├── "supplier.s_address"(#2.2)
+            │   │   │   │       │   ├── "supplier.s_comment"(#2.6)
+            │   │   │   │       │   ├── "supplier.s_name"(#2.1)
+            │   │   │   │       │   ├── "supplier.s_nationkey"(#2.3)
+            │   │   │   │       │   ├── "supplier.s_phone"(#2.4)
+            │   │   │   │       │   └── "supplier.s_suppkey"(#2.0)
+            │   │   │   │       └── (.cardinality): 0.00
+            │   │   │   └── Get
+            │   │   │       ├── .data_source_id: 5
+            │   │   │       ├── .table_index: 3
+            │   │   │       ├── .implementation: None
+            │   │   │       ├── (.output_columns): [ "partsupp.ps_partkey"(#3.0), "partsupp.ps_suppkey"(#3.1), "partsupp.ps_supplycost"(#3.3) ]
+            │   │   │       └── (.cardinality): 0.00
+            │   │   └── Get
+            │   │       ├── .data_source_id: 1
+            │   │       ├── .table_index: 4
+            │   │       ├── .implementation: None
+            │   │       ├── (.output_columns): [ "nation.n_name"(#4.1), "nation.n_nationkey"(#4.0), "nation.n_regionkey"(#4.2) ]
+            │   │       └── (.cardinality): 0.00
+            │   └── Select
+            │       ├── .predicate: "region.r_name"(#5.1) = 'AFRICA'::utf8_view
+            │       ├── (.output_columns): [ "region.r_name"(#5.1), "region.r_regionkey"(#5.0) ]
+            │       ├── (.cardinality): 0.00
+            │       └── Get
+            │           ├── .data_source_id: 2
+            │           ├── .table_index: 5
+            │           ├── .implementation: None
+            │           ├── (.output_columns): [ "region.r_name"(#5.1), "region.r_regionkey"(#5.0) ]
+            │           └── (.cardinality): 0.00
+            └── Project
+                ├── .table_index: 18
+                ├── .projections: [ "__#17.min"(#17.0), "__#14.p_partkey"(#14.0) ]
+                ├── (.output_columns): [ "__#18.min"(#18.0), "__#18.p_partkey"(#18.1) ]
+                ├── (.cardinality): 0.00
+                └── Join
+                    ├── .join_type: LeftOuter
+                    ├── .implementation: None
+                    ├── .join_cond: "__#14.p_partkey"(#14.0) IS NOT DISTINCT FROM "__#16.ps_partkey"(#16.0)
+                    ├── (.output_columns): [ "__#14.p_partkey"(#14.0), "__#16.ps_partkey"(#16.0), "__#17.min"(#17.0) ]
+                    ├── (.cardinality): 0.00
+                    ├── Aggregate
+                    │   ├── .key_table_index: 14
+                    │   ├── .aggregate_table_index: 15
+                    │   ├── .implementation: None
+                    │   ├── .exprs: []
+                    │   ├── .keys: "part.p_partkey"(#1.0)
+                    │   ├── (.output_columns): "__#14.p_partkey"(#14.0)
+                    │   ├── (.cardinality): 0.00
+                    │   └── Join
+                    │       ├── .join_type: Inner
+                    │       ├── .implementation: None
+                    │       ├── .join_cond: "nation.n_regionkey"(#4.2) = "region.r_regionkey"(#5.0)
+                    │       ├── (.output_columns):
+                    │       │   ┌── "nation.n_nationkey"(#4.0)
+                    │       │   ├── "nation.n_regionkey"(#4.2)
+                    │       │   ├── "part.p_partkey"(#1.0)
+                    │       │   ├── "part.p_size"(#1.5)
+                    │       │   ├── "part.p_type"(#1.4)
+                    │       │   ├── "partsupp.ps_partkey"(#3.0)
+                    │       │   ├── "partsupp.ps_suppkey"(#3.1)
+                    │       │   ├── "region.r_name"(#5.1)
+                    │       │   ├── "region.r_regionkey"(#5.0)
+                    │       │   ├── "supplier.s_nationkey"(#2.3)
+                    │       │   └── "supplier.s_suppkey"(#2.0)
+                    │       ├── (.cardinality): 0.00
+                    │       ├── Join
+                    │       │   ├── .join_type: Inner
+                    │       │   ├── .implementation: None
+                    │       │   ├── .join_cond: "supplier.s_nationkey"(#2.3) = "nation.n_nationkey"(#4.0)
+                    │       │   ├── (.output_columns):
+                    │       │   │   ┌── "nation.n_nationkey"(#4.0)
+                    │       │   │   ├── "nation.n_regionkey"(#4.2)
+                    │       │   │   ├── "part.p_partkey"(#1.0)
+                    │       │   │   ├── "part.p_size"(#1.5)
+                    │       │   │   ├── "part.p_type"(#1.4)
+                    │       │   │   ├── "partsupp.ps_partkey"(#3.0)
+                    │       │   │   ├── "partsupp.ps_suppkey"(#3.1)
+                    │       │   │   ├── "supplier.s_nationkey"(#2.3)
+                    │       │   │   └── "supplier.s_suppkey"(#2.0)
+                    │       │   ├── (.cardinality): 0.00
+                    │       │   ├── Join
+                    │       │   │   ├── .join_type: Inner
+                    │       │   │   ├── .implementation: None
+                    │       │   │   ├── .join_cond: ("part.p_partkey"(#1.0) = "partsupp.ps_partkey"(#3.0)) AND ("supplier.s_suppkey"(#2.0) = "partsupp.ps_suppkey"(#3.1))
+                    │       │   │   ├── (.output_columns):
+                    │       │   │   │   ┌── "part.p_partkey"(#1.0)
+                    │       │   │   │   ├── "part.p_size"(#1.5)
+                    │       │   │   │   ├── "part.p_type"(#1.4)
+                    │       │   │   │   ├── "partsupp.ps_partkey"(#3.0)
+                    │       │   │   │   ├── "partsupp.ps_suppkey"(#3.1)
+                    │       │   │   │   ├── "supplier.s_nationkey"(#2.3)
+                    │       │   │   │   └── "supplier.s_suppkey"(#2.0)
+                    │       │   │   ├── (.cardinality): 0.00
+                    │       │   │   ├── Join
+                    │       │   │   │   ├── .join_type: Inner
+                    │       │   │   │   ├── .implementation: None
+                    │       │   │   │   ├── .join_cond: true::boolean
+                    │       │   │   │   ├── (.output_columns):
+                    │       │   │   │   │   ┌── "part.p_partkey"(#1.0)
+                    │       │   │   │   │   ├── "part.p_size"(#1.5)
+                    │       │   │   │   │   ├── "part.p_type"(#1.4)
+                    │       │   │   │   │   ├── "supplier.s_nationkey"(#2.3)
+                    │       │   │   │   │   └── "supplier.s_suppkey"(#2.0)
+                    │       │   │   │   ├── (.cardinality): 0.00
+                    │       │   │   │   ├── Select
+                    │       │   │   │   │   ├── .predicate: ("part.p_size"(#1.5) = 4::integer) AND ("part.p_type"(#1.4) LIKE '%TIN'::utf8_view)
+                    │       │   │   │   │   ├── (.output_columns): [ "part.p_partkey"(#1.0), "part.p_size"(#1.5), "part.p_type"(#1.4) ]
+                    │       │   │   │   │   ├── (.cardinality): 0.00
+                    │       │   │   │   │   └── Get
+                    │       │   │   │   │       ├── .data_source_id: 3
+                    │       │   │   │   │       ├── .table_index: 1
+                    │       │   │   │   │       ├── .implementation: None
+                    │       │   │   │   │       ├── (.output_columns): [ "part.p_partkey"(#1.0), "part.p_size"(#1.5), "part.p_type"(#1.4) ]
+                    │       │   │   │   │       └── (.cardinality): 0.00
+                    │       │   │   │   └── Get
+                    │       │   │   │       ├── .data_source_id: 4
+                    │       │   │   │       ├── .table_index: 2
+                    │       │   │   │       ├── .implementation: None
+                    │       │   │   │       ├── (.output_columns): [ "supplier.s_nationkey"(#2.3), "supplier.s_suppkey"(#2.0) ]
+                    │       │   │   │       └── (.cardinality): 0.00
+                    │       │   │   └── Get
+                    │       │   │       ├── .data_source_id: 5
+                    │       │   │       ├── .table_index: 3
+                    │       │   │       ├── .implementation: None
+                    │       │   │       ├── (.output_columns): [ "partsupp.ps_partkey"(#3.0), "partsupp.ps_suppkey"(#3.1) ]
+                    │       │   │       └── (.cardinality): 0.00
+                    │       │   └── Get
+                    │       │       ├── .data_source_id: 1
+                    │       │       ├── .table_index: 4
+                    │       │       ├── .implementation: None
+                    │       │       ├── (.output_columns): [ "nation.n_nationkey"(#4.0), "nation.n_regionkey"(#4.2) ]
+                    │       │       └── (.cardinality): 0.00
+                    │       └── Select
+                    │           ├── .predicate: "region.r_name"(#5.1) = 'AFRICA'::utf8_view
+                    │           ├── (.output_columns): [ "region.r_name"(#5.1), "region.r_regionkey"(#5.0) ]
+                    │           ├── (.cardinality): 0.00
+                    │           └── Get
+                    │               ├── .data_source_id: 2
+                    │               ├── .table_index: 5
+                    │               ├── .implementation: None
+                    │               ├── (.output_columns): [ "region.r_name"(#5.1), "region.r_regionkey"(#5.0) ]
+                    │               └── (.cardinality): 0.00
+                    └── Aggregate
+                        ├── .key_table_index: 16
+                        ├── .aggregate_table_index: 17
+                        ├── .implementation: None
+                        ├── .exprs: min("partsupp.ps_supplycost"(#6.3))
+                        ├── .keys: "partsupp.ps_partkey"(#6.0)
+                        ├── (.output_columns): [ "__#16.ps_partkey"(#16.0), "__#17.min"(#17.0) ]
+                        ├── (.cardinality): 0.00
+                        └── Join
+                            ├── .join_type: Inner
+                            ├── .implementation: None
+                            ├── .join_cond: "nation.n_regionkey"(#8.2) = "region.r_regionkey"(#9.0)
+                            ├── (.output_columns):
+                            │   ┌── "nation.n_nationkey"(#8.0)
+                            │   ├── "nation.n_regionkey"(#8.2)
+                            │   ├── "partsupp.ps_partkey"(#6.0)
+                            │   ├── "partsupp.ps_suppkey"(#6.1)
+                            │   ├── "partsupp.ps_supplycost"(#6.3)
+                            │   ├── "region.r_name"(#9.1)
+                            │   ├── "region.r_regionkey"(#9.0)
+                            │   ├── "supplier.s_nationkey"(#7.3)
+                            │   └── "supplier.s_suppkey"(#7.0)
+                            ├── (.cardinality): 0.00
+                            ├── Join
+                            │   ├── .join_type: Inner
+                            │   ├── .implementation: None
+                            │   ├── .join_cond: "supplier.s_nationkey"(#7.3) = "nation.n_nationkey"(#8.0)
+                            │   ├── (.output_columns):
+                            │   │   ┌── "nation.n_nationkey"(#8.0)
+                            │   │   ├── "nation.n_regionkey"(#8.2)
+                            │   │   ├── "partsupp.ps_partkey"(#6.0)
+                            │   │   ├── "partsupp.ps_suppkey"(#6.1)
+                            │   │   ├── "partsupp.ps_supplycost"(#6.3)
+                            │   │   ├── "supplier.s_nationkey"(#7.3)
+                            │   │   └── "supplier.s_suppkey"(#7.0)
+                            │   ├── (.cardinality): 0.00
+                            │   ├── Join
+                            │   │   ├── .join_type: Inner
+                            │   │   ├── .implementation: None
+                            │   │   ├── .join_cond: "supplier.s_suppkey"(#7.0) = "partsupp.ps_suppkey"(#6.1)
+                            │   │   ├── (.output_columns):
+                            │   │   │   ┌── "partsupp.ps_partkey"(#6.0)
+                            │   │   │   ├── "partsupp.ps_suppkey"(#6.1)
+                            │   │   │   ├── "partsupp.ps_supplycost"(#6.3)
+                            │   │   │   ├── "supplier.s_nationkey"(#7.3)
+                            │   │   │   └── "supplier.s_suppkey"(#7.0)
+                            │   │   ├── (.cardinality): 0.00
+                            │   │   ├── Select
+                            │   │   │   ├── .predicate: "partsupp.ps_partkey"(#6.0) = "partsupp.ps_partkey"(#6.0)
+                            │   │   │   ├── (.output_columns): [ "partsupp.ps_partkey"(#6.0), "partsupp.ps_suppkey"(#6.1), "partsupp.ps_supplycost"(#6.3) ]
+                            │   │   │   ├── (.cardinality): 0.00
+                            │   │   │   └── Get
+                            │   │   │       ├── .data_source_id: 5
+                            │   │   │       ├── .table_index: 6
+                            │   │   │       ├── .implementation: None
+                            │   │   │       ├── (.output_columns): [ "partsupp.ps_partkey"(#6.0), "partsupp.ps_suppkey"(#6.1), "partsupp.ps_supplycost"(#6.3) ]
+                            │   │   │       └── (.cardinality): 0.00
+                            │   │   └── Get
+                            │   │       ├── .data_source_id: 4
+                            │   │       ├── .table_index: 7
+                            │   │       ├── .implementation: None
+                            │   │       ├── (.output_columns): [ "supplier.s_nationkey"(#7.3), "supplier.s_suppkey"(#7.0) ]
+                            │   │       └── (.cardinality): 0.00
+                            │   └── Get
+                            │       ├── .data_source_id: 1
+                            │       ├── .table_index: 8
+                            │       ├── .implementation: None
+                            │       ├── (.output_columns): [ "nation.n_nationkey"(#8.0), "nation.n_regionkey"(#8.2) ]
+                            │       └── (.cardinality): 0.00
+                            └── Select
+                                ├── .predicate: "region.r_name"(#9.1) = 'AFRICA'::utf8_view
+                                ├── (.output_columns): [ "region.r_name"(#9.1), "region.r_regionkey"(#9.0) ]
+                                ├── (.cardinality): 0.00
+                                └── Get
+                                    ├── .data_source_id: 2
+                                    ├── .table_index: 9
+                                    ├── .implementation: None
+                                    ├── (.output_columns): [ "region.r_name"(#9.1), "region.r_regionkey"(#9.0) ]
+                                    └── (.cardinality): 0.00
 */
 

--- a/tests/sqlplannertest/tests/tpch/q2.planner.sql
+++ b/tests/sqlplannertest/tests/tpch/q2.planner.sql
@@ -46,6 +46,6 @@ limit 100;
 
 /*
 Error
-Schema error: No field named "__#14".p_partkey.
+Schema error: No field named "__#11"."min(partsupp.ps_supplycost)". Valid fields are part.p_partkey, partsupp.ps_partkey, "__#17".min.
 */
 

--- a/tests/sqlplannertest/tests/tpch/q20.planner.sql
+++ b/tests/sqlplannertest/tests/tpch/q20.planner.sql
@@ -39,6 +39,6 @@ order by
 
 /*
 Error
-Schema error: No field named "__#14".ps_partkey.
+Schema error: No field named "__#8"."sum(lineitem.l_quantity)". Did you mean 'lineitem.l_partkey'?.
 */
 

--- a/tests/sqlplannertest/tests/tpch/q20.planner.sql
+++ b/tests/sqlplannertest/tests/tpch/q20.planner.sql
@@ -38,7 +38,148 @@ order by
     s_name;
 
 /*
-Error
-Schema error: No field named "__#8"."sum(lineitem.l_quantity)". Did you mean 'lineitem.l_partkey'?.
+logical_plan after optd-initial:
+OrderBy { ordering_exprs: "__#11.s_name"(#11.0) ASC, (.output_columns): [ "__#11.s_address"(#11.1), "__#11.s_name"(#11.0) ], (.cardinality): 0.00 }
+└── Project { .table_index: 11, .projections: [ "supplier.s_name"(#1.1), "supplier.s_address"(#1.2) ], (.output_columns): [ "__#11.s_address"(#11.1), "__#11.s_name"(#11.0) ], (.cardinality): 0.00 }
+    └── Select
+        ├── .predicate: ("supplier.s_nationkey"(#1.3) = "nation.n_nationkey"(#2.0)) AND ("nation.n_name"(#2.1) = CAST ('IRAQ'::utf8 AS Utf8View))
+        ├── (.output_columns): [ "nation.n_comment"(#2.3), "nation.n_name"(#2.1), "nation.n_nationkey"(#2.0), "nation.n_regionkey"(#2.2), "supplier.s_acctbal"(#1.5), "supplier.s_address"(#1.2), "supplier.s_comment"(#1.6), "supplier.s_name"(#1.1), "supplier.s_nationkey"(#1.3), "supplier.s_phone"(#1.4), "supplier.s_suppkey"(#1.0) ]
+        ├── (.cardinality): 0.00
+        └── DependentJoin
+            ├── .join_type: LeftSemi
+            ├── .join_cond: "supplier.s_suppkey"(#1.0) = "__#10.ps_suppkey"(#10.0)
+            ├── (.output_columns): [ "nation.n_comment"(#2.3), "nation.n_name"(#2.1), "nation.n_nationkey"(#2.0), "nation.n_regionkey"(#2.2), "supplier.s_acctbal"(#1.5), "supplier.s_address"(#1.2), "supplier.s_comment"(#1.6), "supplier.s_name"(#1.1), "supplier.s_nationkey"(#1.3), "supplier.s_phone"(#1.4), "supplier.s_suppkey"(#1.0) ]
+            ├── (.cardinality): 0.00
+            ├── Join
+            │   ├── .join_type: Inner
+            │   ├── .implementation: None
+            │   ├── .join_cond: 
+            │   ├── (.output_columns): [ "nation.n_comment"(#2.3), "nation.n_name"(#2.1), "nation.n_nationkey"(#2.0), "nation.n_regionkey"(#2.2), "supplier.s_acctbal"(#1.5), "supplier.s_address"(#1.2), "supplier.s_comment"(#1.6), "supplier.s_name"(#1.1), "supplier.s_nationkey"(#1.3), "supplier.s_phone"(#1.4), "supplier.s_suppkey"(#1.0) ]
+            │   ├── (.cardinality): 0.00
+            │   ├── Get { .data_source_id: 4, .table_index: 1, .implementation: None, (.output_columns): [ "supplier.s_acctbal"(#1.5), "supplier.s_address"(#1.2), "supplier.s_comment"(#1.6), "supplier.s_name"(#1.1), "supplier.s_nationkey"(#1.3), "supplier.s_phone"(#1.4), "supplier.s_suppkey"(#1.0) ], (.cardinality): 0.00 }
+            │   └── Get { .data_source_id: 1, .table_index: 2, .implementation: None, (.output_columns): [ "nation.n_comment"(#2.3), "nation.n_name"(#2.1), "nation.n_nationkey"(#2.0), "nation.n_regionkey"(#2.2) ], (.cardinality): 0.00 }
+            └── Project { .table_index: 10, .projections: "partsupp.ps_suppkey"(#3.1), (.output_columns): "__#10.ps_suppkey"(#10.0), (.cardinality): 0.00 }
+                └── DependentJoin
+                    ├── .join_type: Inner
+                    ├── .join_cond: CAST ("partsupp.ps_availqty"(#3.2) AS Float64) > "__#9.Float64(0.5) * sum(lineitem.l_quantity)"(#9.0)
+                    ├── (.output_columns): [ "__#9.Float64(0.5) * sum(lineitem.l_quantity)"(#9.0), "partsupp.ps_availqty"(#3.2), "partsupp.ps_comment"(#3.4), "partsupp.ps_partkey"(#3.0), "partsupp.ps_suppkey"(#3.1), "partsupp.ps_supplycost"(#3.3) ]
+                    ├── (.cardinality): 0.00
+                    ├── DependentJoin { .join_type: LeftSemi, .join_cond: "partsupp.ps_partkey"(#3.0) = "__#5.p_partkey"(#5.0), (.output_columns): [ "partsupp.ps_availqty"(#3.2), "partsupp.ps_comment"(#3.4), "partsupp.ps_partkey"(#3.0), "partsupp.ps_suppkey"(#3.1), "partsupp.ps_supplycost"(#3.3) ], (.cardinality): 0.00 }
+                    │   ├── Get { .data_source_id: 5, .table_index: 3, .implementation: None, (.output_columns): [ "partsupp.ps_availqty"(#3.2), "partsupp.ps_comment"(#3.4), "partsupp.ps_partkey"(#3.0), "partsupp.ps_suppkey"(#3.1), "partsupp.ps_supplycost"(#3.3) ], (.cardinality): 0.00 }
+                    │   └── Project { .table_index: 5, .projections: "part.p_partkey"(#4.0), (.output_columns): "__#5.p_partkey"(#5.0), (.cardinality): 0.00 }
+                    │       └── Select { .predicate: "part.p_name"(#4.1) LIKE CAST ('indian%'::utf8 AS Utf8View), (.output_columns): [ "part.p_brand"(#4.3), "part.p_comment"(#4.8), "part.p_container"(#4.6), "part.p_mfgr"(#4.2), "part.p_name"(#4.1), "part.p_partkey"(#4.0), "part.p_retailprice"(#4.7), "part.p_size"(#4.5), "part.p_type"(#4.4) ], (.cardinality): 0.00 }
+                    │           └── Get { .data_source_id: 3, .table_index: 4, .implementation: None, (.output_columns): [ "part.p_brand"(#4.3), "part.p_comment"(#4.8), "part.p_container"(#4.6), "part.p_mfgr"(#4.2), "part.p_name"(#4.1), "part.p_partkey"(#4.0), "part.p_retailprice"(#4.7), "part.p_size"(#4.5), "part.p_type"(#4.4) ], (.cardinality): 0.00 }
+                    └── Project { .table_index: 9, .projections: 0.5::float64 * CAST ("__#8.sum(lineitem.l_quantity)"(#8.0) AS Float64), (.output_columns): "__#9.Float64(0.5) * sum(lineitem.l_quantity)"(#9.0), (.cardinality): 1.00 }
+                        └── Aggregate { .key_table_index: 7, .aggregate_table_index: 8, .implementation: None, .exprs: sum("lineitem.l_quantity"(#6.4)), .keys: [], (.output_columns): "__#8.sum(lineitem.l_quantity)"(#8.0), (.cardinality): 1.00 }
+                            └── Select
+                                ├── .predicate: ("lineitem.l_partkey"(#6.1) = "partsupp.ps_partkey"(#3.0)) AND ("lineitem.l_suppkey"(#6.2) = "partsupp.ps_suppkey"(#3.1)) AND ("lineitem.l_shipdate"(#6.10) >= CAST ('1996-01-01'::utf8 AS Date32)) AND ("lineitem.l_shipdate"(#6.10) < CAST ('1996-01-01'::utf8 AS Date32) + IntervalMonthDayNano { months: 12, days: 0, nanoseconds: 0 }::interval_month_day_nano)
+                                ├── (.output_columns):
+                                │   ┌── "lineitem.l_comment"(#6.15)
+                                │   ├── "lineitem.l_commitdate"(#6.11)
+                                │   ├── "lineitem.l_discount"(#6.6)
+                                │   ├── "lineitem.l_extendedprice"(#6.5)
+                                │   ├── "lineitem.l_linenumber"(#6.3)
+                                │   ├── "lineitem.l_linestatus"(#6.9)
+                                │   ├── "lineitem.l_orderkey"(#6.0)
+                                │   ├── "lineitem.l_partkey"(#6.1)
+                                │   ├── "lineitem.l_quantity"(#6.4)
+                                │   ├── "lineitem.l_receiptdate"(#6.12)
+                                │   ├── "lineitem.l_returnflag"(#6.8)
+                                │   ├── "lineitem.l_shipdate"(#6.10)
+                                │   ├── "lineitem.l_shipinstruct"(#6.13)
+                                │   ├── "lineitem.l_shipmode"(#6.14)
+                                │   ├── "lineitem.l_suppkey"(#6.2)
+                                │   └── "lineitem.l_tax"(#6.7)
+                                ├── (.cardinality): 0.00
+                                └── Get
+                                    ├── .data_source_id: 8
+                                    ├── .table_index: 6
+                                    ├── .implementation: None
+                                    ├── (.output_columns):
+                                    │   ┌── "lineitem.l_comment"(#6.15)
+                                    │   ├── "lineitem.l_commitdate"(#6.11)
+                                    │   ├── "lineitem.l_discount"(#6.6)
+                                    │   ├── "lineitem.l_extendedprice"(#6.5)
+                                    │   ├── "lineitem.l_linenumber"(#6.3)
+                                    │   ├── "lineitem.l_linestatus"(#6.9)
+                                    │   ├── "lineitem.l_orderkey"(#6.0)
+                                    │   ├── "lineitem.l_partkey"(#6.1)
+                                    │   ├── "lineitem.l_quantity"(#6.4)
+                                    │   ├── "lineitem.l_receiptdate"(#6.12)
+                                    │   ├── "lineitem.l_returnflag"(#6.8)
+                                    │   ├── "lineitem.l_shipdate"(#6.10)
+                                    │   ├── "lineitem.l_shipinstruct"(#6.13)
+                                    │   ├── "lineitem.l_shipmode"(#6.14)
+                                    │   ├── "lineitem.l_suppkey"(#6.2)
+                                    │   └── "lineitem.l_tax"(#6.7)
+                                    └── (.cardinality): 0.00
+
+physical_plan after optd-finalized:
+EnforcerSort { tuple_ordering: [(#11.0, Asc)], (.output_columns): [ "__#11.s_address"(#11.1), "__#11.s_name"(#11.0) ], (.cardinality): 0.00 }
+└── Project { .table_index: 11, .projections: [ "supplier.s_name"(#1.1), "supplier.s_address"(#1.2) ], (.output_columns): [ "__#11.s_address"(#11.1), "__#11.s_name"(#11.0) ], (.cardinality): 0.00 }
+    └── Join
+        ├── .join_type: LeftSemi
+        ├── .implementation: None
+        ├── .join_cond: "supplier.s_suppkey"(#1.0) = "__#19.ps_suppkey"(#19.0)
+        ├── (.output_columns): [ "nation.n_name"(#2.1), "nation.n_nationkey"(#2.0), "supplier.s_address"(#1.2), "supplier.s_name"(#1.1), "supplier.s_nationkey"(#1.3), "supplier.s_suppkey"(#1.0) ]
+        ├── (.cardinality): 0.00
+        ├── Join
+        │   ├── .join_type: Inner
+        │   ├── .implementation: None
+        │   ├── .join_cond: "supplier.s_nationkey"(#1.3) = "nation.n_nationkey"(#2.0)
+        │   ├── (.output_columns): [ "nation.n_name"(#2.1), "nation.n_nationkey"(#2.0), "supplier.s_address"(#1.2), "supplier.s_name"(#1.1), "supplier.s_nationkey"(#1.3), "supplier.s_suppkey"(#1.0) ]
+        │   ├── (.cardinality): 0.00
+        │   ├── Get { .data_source_id: 4, .table_index: 1, .implementation: None, (.output_columns): [ "supplier.s_address"(#1.2), "supplier.s_name"(#1.1), "supplier.s_nationkey"(#1.3), "supplier.s_suppkey"(#1.0) ], (.cardinality): 0.00 }
+        │   └── Select { .predicate: "nation.n_name"(#2.1) = 'IRAQ'::utf8_view, (.output_columns): [ "nation.n_name"(#2.1), "nation.n_nationkey"(#2.0) ], (.cardinality): 0.00 }
+        │       └── Get { .data_source_id: 1, .table_index: 2, .implementation: None, (.output_columns): [ "nation.n_name"(#2.1), "nation.n_nationkey"(#2.0) ], (.cardinality): 0.00 }
+        └── Project { .table_index: 19, .projections: "partsupp.ps_suppkey"(#3.1), (.output_columns): "__#19.ps_suppkey"(#19.0), (.cardinality): 0.00 }
+            └── Join
+                ├── .join_type: Inner
+                ├── .implementation: None
+                ├── .join_cond: ("partsupp.ps_partkey"(#3.0) IS NOT DISTINCT FROM "__#18.ps_partkey"(#18.1)) AND ("partsupp.ps_suppkey"(#3.1) IS NOT DISTINCT FROM "__#18.ps_suppkey"(#18.2)) AND (CAST ("partsupp.ps_availqty"(#3.2) AS Float64) > "__#18.expr0"(#18.0))
+                ├── (.output_columns): [ "__#18.expr0"(#18.0), "__#18.ps_partkey"(#18.1), "__#18.ps_suppkey"(#18.2), "partsupp.ps_availqty"(#3.2), "partsupp.ps_partkey"(#3.0), "partsupp.ps_suppkey"(#3.1) ]
+                ├── (.cardinality): 0.00
+                ├── Join { .join_type: LeftSemi, .implementation: None, .join_cond: "partsupp.ps_partkey"(#3.0) = "__#5.p_partkey"(#5.0), (.output_columns): [ "partsupp.ps_availqty"(#3.2), "partsupp.ps_partkey"(#3.0), "partsupp.ps_suppkey"(#3.1) ], (.cardinality): 0.00 }
+                │   ├── Get { .data_source_id: 5, .table_index: 3, .implementation: None, (.output_columns): [ "partsupp.ps_availqty"(#3.2), "partsupp.ps_partkey"(#3.0), "partsupp.ps_suppkey"(#3.1) ], (.cardinality): 0.00 }
+                │   └── Project { .table_index: 5, .projections: "part.p_partkey"(#4.0), (.output_columns): "__#5.p_partkey"(#5.0), (.cardinality): 0.00 }
+                │       └── Select { .predicate: "part.p_name"(#4.1) LIKE 'indian%'::utf8_view, (.output_columns): [ "part.p_name"(#4.1), "part.p_partkey"(#4.0) ], (.cardinality): 0.00 }
+                │           └── Get { .data_source_id: 3, .table_index: 4, .implementation: None, (.output_columns): [ "part.p_name"(#4.1), "part.p_partkey"(#4.0) ], (.cardinality): 0.00 }
+                └── Project
+                    ├── .table_index: 18
+                    ├── .projections: [ 0.5::float64 * CAST ("__#17.sum"(#17.0) AS Float64), "__#14.ps_partkey"(#14.0), "__#14.ps_suppkey"(#14.1) ]
+                    ├── (.output_columns): [ "__#18.expr0"(#18.0), "__#18.ps_partkey"(#18.1), "__#18.ps_suppkey"(#18.2) ]
+                    ├── (.cardinality): 0.00
+                    └── Join
+                        ├── .join_type: LeftOuter
+                        ├── .implementation: None
+                        ├── .join_cond: ("__#14.ps_partkey"(#14.0) IS NOT DISTINCT FROM "__#16.l_partkey"(#16.0)) AND ("__#14.ps_suppkey"(#14.1) IS NOT DISTINCT FROM "__#16.l_suppkey"(#16.1))
+                        ├── (.output_columns): [ "__#14.ps_partkey"(#14.0), "__#14.ps_suppkey"(#14.1), "__#16.l_partkey"(#16.0), "__#16.l_suppkey"(#16.1), "__#17.sum"(#17.0) ]
+                        ├── (.cardinality): 0.00
+                        ├── Aggregate
+                        │   ├── .key_table_index: 14
+                        │   ├── .aggregate_table_index: 15
+                        │   ├── .implementation: None
+                        │   ├── .exprs: []
+                        │   ├── .keys: [ "partsupp.ps_partkey"(#3.0), "partsupp.ps_suppkey"(#3.1) ]
+                        │   ├── (.output_columns): [ "__#14.ps_partkey"(#14.0), "__#14.ps_suppkey"(#14.1) ]
+                        │   ├── (.cardinality): 0.00
+                        │   └── Join { .join_type: LeftSemi, .implementation: None, .join_cond: "partsupp.ps_partkey"(#3.0) = "__#5.p_partkey"(#5.0), (.output_columns): [ "partsupp.ps_partkey"(#3.0), "partsupp.ps_suppkey"(#3.1) ], (.cardinality): 0.00 }
+                        │       ├── Get { .data_source_id: 5, .table_index: 3, .implementation: None, (.output_columns): [ "partsupp.ps_partkey"(#3.0), "partsupp.ps_suppkey"(#3.1) ], (.cardinality): 0.00 }
+                        │       └── Project { .table_index: 5, .projections: "part.p_partkey"(#4.0), (.output_columns): "__#5.p_partkey"(#5.0), (.cardinality): 0.00 }
+                        │           └── Select { .predicate: "part.p_name"(#4.1) LIKE 'indian%'::utf8_view, (.output_columns): [ "part.p_name"(#4.1), "part.p_partkey"(#4.0) ], (.cardinality): 0.00 }
+                        │               └── Get { .data_source_id: 3, .table_index: 4, .implementation: None, (.output_columns): [ "part.p_name"(#4.1), "part.p_partkey"(#4.0) ], (.cardinality): 0.00 }
+                        └── Aggregate
+                            ├── .key_table_index: 16
+                            ├── .aggregate_table_index: 17
+                            ├── .implementation: None
+                            ├── .exprs: sum("lineitem.l_quantity"(#6.4))
+                            ├── .keys: [ "lineitem.l_partkey"(#6.1), "lineitem.l_suppkey"(#6.2) ]
+                            ├── (.output_columns): [ "__#16.l_partkey"(#16.0), "__#16.l_suppkey"(#16.1), "__#17.sum"(#17.0) ]
+                            ├── (.cardinality): 0.00
+                            └── Select
+                                ├── .predicate: ("lineitem.l_partkey"(#6.1) = "lineitem.l_partkey"(#6.1)) AND ("lineitem.l_suppkey"(#6.2) = "lineitem.l_suppkey"(#6.2)) AND ("lineitem.l_shipdate"(#6.10) >= 1996-01-01::date32) AND ("lineitem.l_shipdate"(#6.10) < 1997-01-01::date32)
+                                ├── (.output_columns): [ "lineitem.l_partkey"(#6.1), "lineitem.l_quantity"(#6.4), "lineitem.l_shipdate"(#6.10), "lineitem.l_suppkey"(#6.2) ]
+                                ├── (.cardinality): 0.00
+                                └── Get { .data_source_id: 8, .table_index: 6, .implementation: None, (.output_columns): [ "lineitem.l_partkey"(#6.1), "lineitem.l_quantity"(#6.4), "lineitem.l_shipdate"(#6.10), "lineitem.l_suppkey"(#6.2) ], (.cardinality): 0.00 }
 */
 


### PR DESCRIPTION
## Problem

`from_optd` was reconstructing DataFusion expressions using a planner-global scope stack and fallback name lookup. That made column resolution depend on implicit mutable state instead of the actual outputs visible at each subtree boundary. The result was hard-to-follow logic around rebuilt names, especially after `Project`, `Aggregate`, `Join`, and `Remap`.

## Summary of changes

- Introduced an explicit planner-local `OutputEnv` mapping from optd columns to the DataFusion columns visible for a rebuilt subtree.
- Added `ConvertedPlan`, so `from_optd` can rebuild a subtree and carry its visible output mapping upward together with the `DFLogicalPlan`.
- Refactored `from_optd` conversion to work bottom-up:
  - child subtrees are rebuilt first
  - scalar expressions are rebuilt against the child output env
  - join expressions use a merged env from both sides
- Removed the old `from_optd_column_scopes` stack and the associated reverse-scan lookup path.
- Simplified column resolution by making `try_from_optd_column_in_env` the primary way to resolve columns during plan reconstruction.
- Dropped the `from_optd`-side reverse mark-column bookkeeping that was only needed because of the old scope-based resolution.
- Added doc comments to the new planner-side types and helper functions to make the output-env model explicit.
