### PR TITLE
Decorrelation Simplification Passes

### DIFF
--- a/optd/core/src/rules/simplification/pass.rs
+++ b/optd/core/src/rules/simplification/pass.rs
@@ -1,9 +1,10 @@
 use super::{
     prune::ColumnPruningRulePass,
     rewrite::{
-        MergeProjectRulePass, MergeSelectRulePass, PushJoinConditionIntoInputsRulePass,
-        PushLimitThroughProjectRulePass, PushSelectThroughJoinRulePass,
-        PushSelectThroughProjectRulePass, ScalarSimplificationRulePass,
+        EliminateNullRejectedLeftOuterJoinRulePass, MergeProjectRulePass, MergeSelectRulePass,
+        PushJoinConditionIntoInputsRulePass, PushLimitThroughProjectRulePass,
+        PushSelectThroughJoinRulePass, PushSelectThroughProjectRulePass,
+        RemoveRedundantDomainJoinRulePass, ScalarSimplificationRulePass,
     },
     rule::RulePass,
 };
@@ -21,6 +22,7 @@ const MAX_ITERATIONS: usize = 10;
 ///
 /// This pass focuses on common rewrites:
 /// - scalar simplification
+/// - decorrelation cleanup
 /// - filter/predicate pushdown
 /// - select/project merging
 /// - top-down column pruning (including `LogicalGet` projection pruning)
@@ -44,8 +46,10 @@ impl SimplificationPass {
 
     /// Applies simplification rules until the plan reaches a fixed point.
     pub fn apply(&self, root: Arc<Operator>, ctx: &IRContext) -> Result<Arc<Operator>> {
-        let rules: [&dyn RulePass; 8] = [
+        let rules: [&dyn RulePass; 10] = [
             &ScalarSimplificationRulePass,
+            &EliminateNullRejectedLeftOuterJoinRulePass,
+            &RemoveRedundantDomainJoinRulePass,
             &MergeSelectRulePass,
             &PushSelectThroughProjectRulePass,
             &PushSelectThroughJoinRulePass,

--- a/optd/core/src/rules/simplification/rewrite/decorrelation.rs
+++ b/optd/core/src/rules/simplification/rewrite/decorrelation.rs
@@ -1,0 +1,633 @@
+//! Simplification rules for plans produced by decorrelating static scalar
+//! aggregates.
+//!
+//! Neumann-style static aggregate decorrelation introduces a distinct domain
+//! relation for the correlated outer keys, then left-joins that domain to the
+//! aggregate value side so unmatched outer keys can still produce a NULL
+//! aggregate result.
+//!
+//! The cleanup here is intentionally ordered:
+//!
+//! 1. `EliminateNullRejectedLeftOuterJoinRulePass` walks null-rejection facts
+//!    down the plan. A predicate above the decorrelated aggregate may reject the
+//!    NULL-extended aggregate result, which makes the decorrelation-introduced
+//!    `LeftOuter` join equivalent to an `Inner` join. Those facts are propagated
+//!    through null-propagating projections, so a rejection on `Project(x + 1)`
+//!    rejects `x`, while a rejection on `coalesce(x, 0)` does not.
+//! 2. `RemoveRedundantDomainJoinRulePass` then looks for the resulting
+//!    `Project(Domain INNER JOIN AggregateValue)` shape. Once the join is inner,
+//!    the domain no longer needs to preserve rows for missing aggregate groups.
+//!    If every domain key is equated to a value-side aggregate key and the
+//!    parent join already binds those projected domain keys back to the original
+//!    outer columns, the domain side is redundant and can be removed.
+//!
+//! `RemoveRedundantDomainJoinRulePass` relies on
+//! `EliminateNullRejectedLeftOuterJoinRulePass` having run first; otherwise it
+//! could remove the domain side while it is still preserving scalar aggregate
+//! NULL-extension semantics.
+
+use super::super::{
+    rule::RulePass,
+    scalar::{combine_conjuncts_simplified, split_conjuncts, substitute_columns},
+};
+use crate::{
+    error::Result,
+    ir::{
+        Column, ColumnSet, IRContext, Operator, Scalar, ScalarKind,
+        convert::{IntoOperator, IntoScalar},
+        operator::{Aggregate, Join, Project, Select, join::JoinType},
+        scalar::{BinaryOp, BinaryOpKind, Cast, ColumnRef, InList, IsNotNull, Like, List, NaryOp},
+    },
+};
+use std::{collections::HashMap, sync::Arc};
+
+/// Converts decorrelation-introduced `LeftOuter` joins to `Inner` joins when an
+/// ancestor predicate rejects the null-extended side.
+pub struct EliminateNullRejectedLeftOuterJoinRulePass;
+
+/// Removes the distinct-domain side introduced for static aggregate unnesting
+/// once a parent inner join already binds the domain keys to the original
+/// outer-side columns.
+pub struct RemoveRedundantDomainJoinRulePass;
+
+impl RulePass for EliminateNullRejectedLeftOuterJoinRulePass {
+    fn apply(&self, root: Arc<Operator>, ctx: &IRContext) -> Result<Arc<Operator>> {
+        eliminate_null_rejected_left_outer_joins(root, ctx, &ColumnSet::default())
+    }
+}
+
+impl RulePass for RemoveRedundantDomainJoinRulePass {
+    fn apply(&self, root: Arc<Operator>, ctx: &IRContext) -> Result<Arc<Operator>> {
+        rewrite_redundant_domain_joins(root, ctx)
+    }
+}
+
+fn eliminate_null_rejected_left_outer_joins(
+    op: Arc<Operator>,
+    ctx: &IRContext,
+    rejected_outputs: &ColumnSet,
+) -> Result<Arc<Operator>> {
+    if let Ok(select) = op.try_borrow::<Select>() {
+        let input_rejections =
+            rejected_outputs | &predicate_null_rejecting_columns(select.predicate());
+        let new_input = eliminate_null_rejected_left_outer_joins(
+            select.input().clone(),
+            ctx,
+            &input_rejections,
+        )?;
+        return Ok(if new_input == *select.input() {
+            op
+        } else {
+            Select::new(new_input, select.predicate().clone()).into_operator()
+        });
+    }
+
+    if let Ok(project) = op.try_borrow::<Project>() {
+        let input_rejections = rejected_project_input_columns(&project, rejected_outputs);
+        let new_input = eliminate_null_rejected_left_outer_joins(
+            project.input().clone(),
+            ctx,
+            &input_rejections,
+        )?;
+        return Ok(if new_input == *project.input() {
+            op
+        } else {
+            Project::new(
+                *project.table_index(),
+                new_input,
+                project.projections().clone(),
+            )
+            .into_operator()
+        });
+    }
+
+    if let Ok(join) = op.try_borrow::<Join>() {
+        let outer_cols = join.outer().output_columns(ctx)?;
+        let inner_cols = join.inner().output_columns(ctx)?;
+        let mut join_type = *join.join_type();
+        let mut outer_rejections = rejected_outputs & outer_cols.as_ref();
+        let mut inner_rejections = rejected_outputs & inner_cols.as_ref();
+
+        if join_type == JoinType::LeftOuter && !inner_rejections.is_empty() {
+            join_type = JoinType::Inner;
+        }
+
+        if join_type == JoinType::Inner {
+            let join_rejections = predicate_null_rejecting_columns(join.join_cond());
+            outer_rejections |= &(join_rejections.clone() & outer_cols.as_ref());
+            inner_rejections |= &(join_rejections & inner_cols.as_ref());
+        }
+
+        let new_outer =
+            eliminate_null_rejected_left_outer_joins(join.outer().clone(), ctx, &outer_rejections)?;
+        let new_inner =
+            eliminate_null_rejected_left_outer_joins(join.inner().clone(), ctx, &inner_rejections)?;
+
+        return Ok(
+            if new_outer == *join.outer()
+                && new_inner == *join.inner()
+                && join_type == *join.join_type()
+            {
+                op
+            } else {
+                Join::new(
+                    join_type,
+                    new_outer,
+                    new_inner,
+                    join.join_cond().clone(),
+                    join.implementation().clone(),
+                )
+                .into_operator()
+            },
+        );
+    }
+
+    let rewritten_inputs = op
+        .input_operators()
+        .iter()
+        .map(|input| {
+            eliminate_null_rejected_left_outer_joins(input.clone(), ctx, &ColumnSet::default())
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    if rewritten_inputs.as_slice() == op.input_operators() {
+        Ok(op)
+    } else {
+        Ok(Arc::new(op.clone_with_inputs(
+            Some(Arc::from(rewritten_inputs)),
+            None,
+        )))
+    }
+}
+
+fn rejected_project_input_columns(
+    project: &crate::ir::operator::ProjectBorrowed<'_>,
+    rejected_outputs: &ColumnSet,
+) -> ColumnSet {
+    let Ok(projections) = project.projections().try_borrow::<List>() else {
+        return ColumnSet::default();
+    };
+
+    let mut rejected_inputs = ColumnSet::default();
+    for (idx, projection) in projections.members().iter().enumerate() {
+        if rejected_outputs.contains(&Column(*project.table_index(), idx)) {
+            rejected_inputs |= &null_propagating_columns(projection);
+        }
+    }
+    rejected_inputs
+}
+
+fn predicate_null_rejecting_columns(predicate: &Arc<Scalar>) -> ColumnSet {
+    match &predicate.kind {
+        ScalarKind::BinaryOp(meta) => {
+            let binary = BinaryOp::borrow_raw_parts(meta, &predicate.common);
+            match binary.op_kind() {
+                BinaryOpKind::Eq
+                | BinaryOpKind::Ne
+                | BinaryOpKind::Lt
+                | BinaryOpKind::Le
+                | BinaryOpKind::Gt
+                | BinaryOpKind::Ge
+                | BinaryOpKind::RegexMatch
+                | BinaryOpKind::RegexIMatch
+                | BinaryOpKind::RegexNotMatch
+                | BinaryOpKind::RegexNotIMatch
+                | BinaryOpKind::LikeMatch
+                | BinaryOpKind::ILikeMatch
+                | BinaryOpKind::NotLikeMatch
+                | BinaryOpKind::NotILikeMatch => {
+                    null_propagating_columns(binary.lhs()) | &null_propagating_columns(binary.rhs())
+                }
+                BinaryOpKind::IsDistinctFrom | BinaryOpKind::IsNotDistinctFrom => {
+                    ColumnSet::default()
+                }
+                _ => ColumnSet::default(),
+            }
+        }
+        ScalarKind::NaryOp(meta) => {
+            let nary = NaryOp::borrow_raw_parts(meta, &predicate.common);
+            if nary.is_and() {
+                nary.terms()
+                    .iter()
+                    .fold(ColumnSet::default(), |mut acc, term| {
+                        acc |= &predicate_null_rejecting_columns(term);
+                        acc
+                    })
+            } else {
+                let mut terms = nary.terms().iter();
+                let Some(first) = terms.next() else {
+                    return ColumnSet::default();
+                };
+                terms.fold(predicate_null_rejecting_columns(first), |acc, term| {
+                    acc & &predicate_null_rejecting_columns(term)
+                })
+            }
+        }
+        ScalarKind::IsNotNull(meta) => {
+            let is_not_null = IsNotNull::borrow_raw_parts(meta, &predicate.common);
+            null_propagating_columns(is_not_null.expr())
+        }
+        ScalarKind::Like(meta) => {
+            let like = Like::borrow_raw_parts(meta, &predicate.common);
+            null_propagating_columns(like.expr()) | &null_propagating_columns(like.pattern())
+        }
+        ScalarKind::InList(meta) => {
+            let in_list = InList::borrow_raw_parts(meta, &predicate.common);
+            null_propagating_columns(in_list.expr()) | &null_propagating_columns(in_list.list())
+        }
+        ScalarKind::Literal(_)
+        | ScalarKind::ColumnRef(_)
+        | ScalarKind::List(_)
+        | ScalarKind::Function(_)
+        | ScalarKind::Cast(_)
+        | ScalarKind::IsNull(_)
+        | ScalarKind::Case(_) => ColumnSet::default(),
+    }
+}
+
+fn null_propagating_columns(scalar: &Arc<Scalar>) -> ColumnSet {
+    match &scalar.kind {
+        ScalarKind::ColumnRef(meta) => {
+            let column_ref = ColumnRef::borrow_raw_parts(meta, &scalar.common);
+            std::iter::once(*column_ref.column()).collect()
+        }
+        ScalarKind::Cast(meta) => {
+            let cast = Cast::borrow_raw_parts(meta, &scalar.common);
+            null_propagating_columns(cast.expr())
+        }
+        ScalarKind::BinaryOp(meta) => {
+            let binary = BinaryOp::borrow_raw_parts(meta, &scalar.common);
+            match binary.op_kind() {
+                BinaryOpKind::Plus
+                | BinaryOpKind::Minus
+                | BinaryOpKind::Multiply
+                | BinaryOpKind::Divide
+                | BinaryOpKind::Modulo
+                | BinaryOpKind::Eq
+                | BinaryOpKind::Ne
+                | BinaryOpKind::Lt
+                | BinaryOpKind::Le
+                | BinaryOpKind::Gt
+                | BinaryOpKind::Ge
+                | BinaryOpKind::RegexMatch
+                | BinaryOpKind::RegexIMatch
+                | BinaryOpKind::RegexNotMatch
+                | BinaryOpKind::RegexNotIMatch
+                | BinaryOpKind::LikeMatch
+                | BinaryOpKind::ILikeMatch
+                | BinaryOpKind::NotLikeMatch
+                | BinaryOpKind::NotILikeMatch
+                | BinaryOpKind::BitwiseAnd
+                | BinaryOpKind::BitwiseOr
+                | BinaryOpKind::BitwiseXor
+                | BinaryOpKind::BitwiseShiftRight
+                | BinaryOpKind::BitwiseShiftLeft
+                | BinaryOpKind::StringConcat
+                | BinaryOpKind::AtArrow
+                | BinaryOpKind::ArrowAt
+                | BinaryOpKind::Arrow
+                | BinaryOpKind::LongArrow
+                | BinaryOpKind::HashArrow
+                | BinaryOpKind::HashLongArrow
+                | BinaryOpKind::AtAt
+                | BinaryOpKind::IntegerDivide
+                | BinaryOpKind::HashMinus
+                | BinaryOpKind::AtQuestion
+                | BinaryOpKind::Question
+                | BinaryOpKind::QuestionAnd
+                | BinaryOpKind::QuestionPipe => {
+                    null_propagating_columns(binary.lhs()) | &null_propagating_columns(binary.rhs())
+                }
+                BinaryOpKind::IsDistinctFrom | BinaryOpKind::IsNotDistinctFrom => {
+                    ColumnSet::default()
+                }
+            }
+        }
+        ScalarKind::Like(meta) => {
+            let like = Like::borrow_raw_parts(meta, &scalar.common);
+            null_propagating_columns(like.expr()) | &null_propagating_columns(like.pattern())
+        }
+        ScalarKind::InList(meta) => {
+            let in_list = InList::borrow_raw_parts(meta, &scalar.common);
+            null_propagating_columns(in_list.expr()) | &null_propagating_columns(in_list.list())
+        }
+        ScalarKind::Literal(_)
+        | ScalarKind::NaryOp(_)
+        | ScalarKind::List(_)
+        | ScalarKind::Function(_)
+        | ScalarKind::IsNull(_)
+        | ScalarKind::IsNotNull(_)
+        | ScalarKind::Case(_) => ColumnSet::default(),
+    }
+}
+
+fn rewrite_redundant_domain_joins(op: Arc<Operator>, ctx: &IRContext) -> Result<Arc<Operator>> {
+    let rewritten_inputs = op
+        .input_operators()
+        .iter()
+        .map(|input| rewrite_redundant_domain_joins(input.clone(), ctx))
+        .collect::<Result<Vec<_>>>()?;
+
+    let op = if rewritten_inputs.as_slice() == op.input_operators() {
+        op
+    } else {
+        Arc::new(op.clone_with_inputs(Some(Arc::from(rewritten_inputs)), None))
+    };
+
+    let Ok(join) = op.try_borrow::<Join>() else {
+        return Ok(op);
+    };
+    if join.join_type() != &JoinType::Inner {
+        return Ok(op);
+    }
+
+    let mut new_outer = join.outer().clone();
+    let mut new_inner = join.inner().clone();
+    let mut parent_cond = join.join_cond().clone();
+    let mut changed = false;
+
+    if let Some(rewrite) =
+        try_remove_domain_from_project(join.outer(), join.inner(), join.join_cond(), ctx)?
+    {
+        new_outer = rewrite.input;
+        parent_cond = rewrite_parent_domain_key_conds(parent_cond, &rewrite.parent_key_bindings);
+        changed = true;
+    }
+
+    if let Some(rewrite) =
+        try_remove_domain_from_project(join.inner(), join.outer(), &parent_cond, ctx)?
+    {
+        new_inner = rewrite.input;
+        parent_cond = rewrite_parent_domain_key_conds(parent_cond, &rewrite.parent_key_bindings);
+        changed = true;
+    }
+
+    Ok(if changed {
+        Join::new(
+            JoinType::Inner,
+            new_outer,
+            new_inner,
+            parent_cond,
+            join.implementation().clone(),
+        )
+        .into_operator()
+    } else {
+        op
+    })
+}
+
+struct DomainProjectRewrite {
+    input: Arc<Operator>,
+    parent_key_bindings: Vec<(Column, Column)>,
+}
+
+fn try_remove_domain_from_project(
+    candidate: &Arc<Operator>,
+    parent_other: &Arc<Operator>,
+    parent_cond: &Arc<Scalar>,
+    ctx: &IRContext,
+) -> Result<Option<DomainProjectRewrite>> {
+    let Ok(project) = candidate.try_borrow::<Project>() else {
+        return Ok(None);
+    };
+    let Ok(domain_join) = project.input().try_borrow::<Join>() else {
+        return Ok(None);
+    };
+    if domain_join.join_type() != &JoinType::Inner {
+        return Ok(None);
+    }
+
+    let outer_domain_rewrite = try_remove_domain_from_project_join_side(
+        &project,
+        domain_join.outer(),
+        domain_join.inner(),
+        domain_join.join_cond(),
+        parent_other,
+        parent_cond,
+        ctx,
+    )?;
+    if outer_domain_rewrite.is_some() {
+        return Ok(outer_domain_rewrite);
+    }
+
+    try_remove_domain_from_project_join_side(
+        &project,
+        domain_join.inner(),
+        domain_join.outer(),
+        domain_join.join_cond(),
+        parent_other,
+        parent_cond,
+        ctx,
+    )
+}
+
+fn try_remove_domain_from_project_join_side(
+    project: &crate::ir::operator::ProjectBorrowed<'_>,
+    domain: &Arc<Operator>,
+    value: &Arc<Operator>,
+    domain_join_cond: &Arc<Scalar>,
+    parent_other: &Arc<Operator>,
+    parent_cond: &Arc<Scalar>,
+    ctx: &IRContext,
+) -> Result<Option<DomainProjectRewrite>> {
+    let Some(domain_key_sources) = domain_key_sources(domain)? else {
+        return Ok(None);
+    };
+    // This is the post-unnesting shape for static scalar aggregates:
+    // Project(D ⋈ Agg), joined above to the original outer input. Once the
+    // left outer join has become inner, D is redundant if every D key is both
+    // equated to an aggregate key and bound by the parent join to its original
+    // outer column.
+    let domain_cols = domain.output_columns(ctx)?;
+    let value_cols = value.output_columns(ctx)?;
+    let Some(domain_to_value) = domain_to_value_key_substitutions(
+        domain_join_cond,
+        domain_cols.as_ref(),
+        value_cols.as_ref(),
+    ) else {
+        return Ok(None);
+    };
+    if !domain_cols
+        .iter()
+        .all(|domain_col| domain_to_value.contains_key(domain_col))
+    {
+        return Ok(None);
+    }
+
+    let Ok(projections) = project.projections().try_borrow::<List>() else {
+        return Ok(None);
+    };
+    if projections.members().iter().any(|projection| {
+        !(projection.used_columns() & domain_cols.as_ref()).is_empty()
+            && !projection
+                .used_columns()
+                .iter()
+                .all(|column| !domain_cols.contains(column) || domain_to_value.contains_key(column))
+    }) {
+        return Ok(None);
+    }
+
+    let project_domain_keys =
+        projected_domain_key_bindings(project, projections.members(), &domain_key_sources);
+    if project_domain_keys.len() != domain_key_sources.len() {
+        return Ok(None);
+    }
+
+    let parent_other_cols = parent_other.output_columns(ctx)?;
+    let mut parent_key_bindings = Vec::with_capacity(project_domain_keys.len());
+    for (project_col, source_col) in project_domain_keys {
+        if !parent_cond_binds_project_key(
+            parent_cond,
+            project_col,
+            source_col,
+            parent_other_cols.as_ref(),
+        ) {
+            return Ok(None);
+        }
+        parent_key_bindings.push((project_col, source_col));
+    }
+
+    let substitutions = domain_to_value
+        .into_iter()
+        .map(|(domain_col, value_col)| (domain_col, ColumnRef::new(value_col).into_scalar()))
+        .collect::<HashMap<_, _>>();
+    let new_projections = substitute_columns(project.projections().clone(), &substitutions);
+    Ok(Some(DomainProjectRewrite {
+        input: Project::new(*project.table_index(), value.clone(), new_projections).into_operator(),
+        parent_key_bindings,
+    }))
+}
+
+fn domain_key_sources(domain: &Arc<Operator>) -> Result<Option<HashMap<Column, Column>>> {
+    let Ok(aggregate) = domain.try_borrow::<Aggregate>() else {
+        return Ok(None);
+    };
+    let Ok(exprs) = aggregate.exprs().try_borrow::<List>() else {
+        return Ok(None);
+    };
+    if !exprs.members().is_empty() {
+        return Ok(None);
+    }
+
+    let Ok(keys) = aggregate.keys().try_borrow::<List>() else {
+        return Ok(None);
+    };
+    let mut sources = HashMap::with_capacity(keys.members().len());
+    for (idx, key) in keys.members().iter().enumerate() {
+        let Ok(column_ref) = key.try_borrow::<ColumnRef>() else {
+            return Ok(None);
+        };
+        sources.insert(
+            Column(*aggregate.key_table_index(), idx),
+            *column_ref.column(),
+        );
+    }
+    Ok(Some(sources))
+}
+
+fn domain_to_value_key_substitutions(
+    join_cond: &Arc<Scalar>,
+    domain_cols: &ColumnSet,
+    value_cols: &ColumnSet,
+) -> Option<HashMap<Column, Column>> {
+    let mut substitutions = HashMap::new();
+    for conjunct in split_conjuncts(join_cond.clone()) {
+        let Some((lhs, rhs, _)) = binary_column_comparison(&conjunct) else {
+            continue;
+        };
+        let mapping = match (
+            domain_cols.contains(&lhs),
+            value_cols.contains(&lhs),
+            domain_cols.contains(&rhs),
+            value_cols.contains(&rhs),
+        ) {
+            (true, false, false, true) => Some((lhs, rhs)),
+            (false, true, true, false) => Some((rhs, lhs)),
+            _ => None,
+        };
+        if let Some((domain_col, value_col)) = mapping {
+            match substitutions.insert(domain_col, value_col) {
+                Some(existing) if existing != value_col => return None,
+                _ => {}
+            }
+        }
+    }
+    Some(substitutions)
+}
+
+fn projected_domain_key_bindings(
+    project: &crate::ir::operator::ProjectBorrowed<'_>,
+    projections: &[Arc<Scalar>],
+    domain_key_sources: &HashMap<Column, Column>,
+) -> Vec<(Column, Column)> {
+    projections
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, projection)| {
+            let column_ref = projection.try_borrow::<ColumnRef>().ok()?;
+            let source_col = domain_key_sources.get(column_ref.column())?;
+            Some((Column(*project.table_index(), idx), *source_col))
+        })
+        .collect()
+}
+
+fn parent_cond_binds_project_key(
+    parent_cond: &Arc<Scalar>,
+    project_col: Column,
+    source_col: Column,
+    parent_other_cols: &ColumnSet,
+) -> bool {
+    parent_other_cols.contains(&source_col)
+        && split_conjuncts(parent_cond.clone())
+            .into_iter()
+            .any(|conjunct| {
+                let Some((lhs, rhs, _)) = binary_column_comparison(&conjunct) else {
+                    return false;
+                };
+                (lhs == project_col && rhs == source_col)
+                    || (lhs == source_col && rhs == project_col)
+            })
+}
+
+fn rewrite_parent_domain_key_conds(
+    parent_cond: Arc<Scalar>,
+    parent_key_bindings: &[(Column, Column)],
+) -> Arc<Scalar> {
+    let rewritten = split_conjuncts(parent_cond)
+        .into_iter()
+        .map(|conjunct| {
+            let Some((lhs, rhs, op_kind)) = binary_column_comparison(&conjunct) else {
+                return conjunct;
+            };
+            if op_kind == BinaryOpKind::IsNotDistinctFrom
+                && parent_key_bindings.iter().any(|(project_col, source_col)| {
+                    (lhs == *project_col && rhs == *source_col)
+                        || (lhs == *source_col && rhs == *project_col)
+                })
+            {
+                BinaryOp::new(
+                    BinaryOpKind::Eq,
+                    ColumnRef::new(lhs).into_scalar(),
+                    ColumnRef::new(rhs).into_scalar(),
+                )
+                .into_scalar()
+            } else {
+                conjunct
+            }
+        })
+        .collect();
+    combine_conjuncts_simplified(rewritten)
+}
+
+fn binary_column_comparison(scalar: &Arc<Scalar>) -> Option<(Column, Column, BinaryOpKind)> {
+    let binary = scalar.try_borrow::<BinaryOp>().ok()?;
+    if !matches!(
+        binary.op_kind(),
+        BinaryOpKind::Eq | BinaryOpKind::IsNotDistinctFrom
+    ) {
+        return None;
+    }
+    let lhs = binary.lhs().try_borrow::<ColumnRef>().ok()?;
+    let rhs = binary.rhs().try_borrow::<ColumnRef>().ok()?;
+    Some((*lhs.column(), *rhs.column(), *binary.op_kind()))
+}

--- a/optd/core/src/rules/simplification/rewrite/mod.rs
+++ b/optd/core/src/rules/simplification/rewrite/mod.rs
@@ -1,3 +1,4 @@
+mod decorrelation;
 mod project;
 mod scalar;
 mod select;
@@ -5,6 +6,9 @@ mod select;
 use crate::ir::{Column, Scalar, scalar::List};
 use std::{collections::HashMap, sync::Arc};
 
+pub use decorrelation::{
+    EliminateNullRejectedLeftOuterJoinRulePass, RemoveRedundantDomainJoinRulePass,
+};
 pub use project::{MergeProjectRulePass, PushLimitThroughProjectRulePass};
 pub use scalar::ScalarSimplificationRulePass;
 pub use select::{

--- a/optd/core/src/rules/simplification/rewrite/scalar.rs
+++ b/optd/core/src/rules/simplification/rewrite/scalar.rs
@@ -4,7 +4,12 @@ use super::super::{
 };
 use crate::{
     error::Result,
-    ir::{IRContext, Operator},
+    ir::{
+        Column, ColumnSet, IRContext, Operator, Scalar, ScalarKind,
+        convert::{IntoOperator, IntoScalar},
+        operator::{DependentJoin, Join, Select},
+        scalar::{BinaryOp, BinaryOpKind, ColumnRef, Literal},
+    },
 };
 use std::sync::Arc;
 
@@ -14,19 +19,125 @@ pub struct ScalarSimplificationRulePass;
 impl RulePass for ScalarSimplificationRulePass {
     fn apply(&self, root: Arc<Operator>, ctx: &IRContext) -> Result<Arc<Operator>> {
         rewrite_bottom_up(root, ctx, &|op, _ctx| {
-            let rewritten_scalars = op
-                .input_scalars()
-                .iter()
-                .map(|scalar| simplify_scalar_recursively_with_ctx(scalar.clone(), ctx))
-                .collect::<Vec<_>>();
-            if rewritten_scalars.as_slice() == op.input_scalars() {
-                Ok(op)
-            } else {
-                Ok(Arc::new(op.clone_with_inputs(
-                    None,
-                    Some(Arc::from(rewritten_scalars)),
-                )))
-            }
+            let op = simplify_attached_scalars(op, ctx);
+            simplify_predicate_self_equalities(op, ctx)
         })
     }
+}
+
+// Simple scalar simplification
+fn simplify_attached_scalars(op: Arc<Operator>, ctx: &IRContext) -> Arc<Operator> {
+    let rewritten_scalars = op
+        .input_scalars()
+        .iter()
+        .map(|scalar| simplify_scalar_recursively_with_ctx(scalar.clone(), ctx))
+        .collect::<Vec<_>>();
+    if rewritten_scalars.as_slice() == op.input_scalars() {
+        op
+    } else {
+        Arc::new(op.clone_with_inputs(None, Some(Arc::from(rewritten_scalars))))
+    }
+}
+
+// Simplifies "COLUMN = COLUMN" filtering predicates if it is known that
+// COLUMN is non-NULL
+fn simplify_predicate_self_equalities(op: Arc<Operator>, ctx: &IRContext) -> Result<Arc<Operator>> {
+    if let Ok(select) = op.try_borrow::<Select>() {
+        let non_null_columns = non_nullable_output_columns(select.input(), ctx)?;
+        let predicate =
+            simplify_non_null_self_equalities(select.predicate().clone(), &non_null_columns);
+        return Ok(if predicate == *select.predicate() {
+            op
+        } else {
+            Select::new(select.input().clone(), predicate).into_operator()
+        });
+    }
+
+    if let Ok(join) = op.try_borrow::<Join>() {
+        let non_null_columns = non_nullable_output_columns(join.outer(), ctx)?
+            | &non_nullable_output_columns(join.inner(), ctx)?;
+        let join_cond =
+            simplify_non_null_self_equalities(join.join_cond().clone(), &non_null_columns);
+        return Ok(if join_cond == *join.join_cond() {
+            op
+        } else {
+            Join::new(
+                *join.join_type(),
+                join.outer().clone(),
+                join.inner().clone(),
+                join_cond,
+                join.implementation().clone(),
+            )
+            .into_operator()
+        });
+    }
+
+    if let Ok(join) = op.try_borrow::<DependentJoin>() {
+        let non_null_columns = non_nullable_output_columns(join.outer(), ctx)?
+            | &non_nullable_output_columns(join.inner(), ctx)?;
+        let join_cond =
+            simplify_non_null_self_equalities(join.join_cond().clone(), &non_null_columns);
+        return Ok(if join_cond == *join.join_cond() {
+            op
+        } else {
+            DependentJoin::new(
+                *join.join_type(),
+                join.outer().clone(),
+                join.inner().clone(),
+                join_cond,
+            )
+            .into_operator()
+        });
+    }
+
+    Ok(op)
+}
+
+fn non_nullable_output_columns(op: &Operator, ctx: &IRContext) -> Result<ColumnSet> {
+    let columns = op.output_columns_in_order(ctx)?;
+    let schema = op.output_schema(ctx)?;
+    Ok(columns
+        .into_iter()
+        .zip(schema.inner().fields().iter())
+        .filter_map(|(column, field)| (!field.is_nullable()).then_some(column))
+        .collect())
+}
+
+fn simplify_non_null_self_equalities(
+    scalar: Arc<Scalar>,
+    non_null_columns: &ColumnSet,
+) -> Arc<Scalar> {
+    let rewritten_inputs = scalar
+        .input_scalars()
+        .iter()
+        .map(|input| simplify_non_null_self_equalities(input.clone(), non_null_columns))
+        .collect::<Vec<_>>();
+    let rewritten = if rewritten_inputs.as_slice() == scalar.input_scalars() {
+        scalar
+    } else {
+        Arc::new(scalar.clone_with_inputs(Some(Arc::from(rewritten_inputs)), None))
+    };
+
+    if let Ok(binary) = rewritten.try_borrow::<BinaryOp>()
+        && binary.op_kind() == &BinaryOpKind::Eq
+        && binary.lhs() == binary.rhs()
+        && referenced_non_null_column(binary.lhs(), non_null_columns).is_some()
+    {
+        return Literal::boolean(true).into_scalar();
+    }
+
+    rewritten.simplify_nary_scalar()
+}
+
+fn referenced_non_null_column(
+    scalar: &Arc<Scalar>,
+    non_null_columns: &ColumnSet,
+) -> Option<Column> {
+    let ScalarKind::ColumnRef(meta) = &scalar.kind else {
+        return None;
+    };
+    let column_ref = ColumnRef::borrow_raw_parts(meta, &scalar.common);
+    non_null_columns
+        .contains(column_ref.column())
+        .then_some(*column_ref.column())
 }

--- a/optd/core/src/rules/simplification/tests.rs
+++ b/optd/core/src/rules/simplification/tests.rs
@@ -1,16 +1,34 @@
 use super::{
     SimplificationPass,
-    scalar::{simplify_scalar_recursively, simplify_scalar_recursively_with_ctx},
+    scalar::{simplify_scalar_recursively, simplify_scalar_recursively_with_ctx, split_conjuncts},
 };
 use crate::ir::{
-    Column, DataType, ScalarValue,
+    Column, DataType, IRContext, ScalarValue,
     builder::*,
-    convert::IntoOperator,
-    operator::{Get, Join, Limit, Project, Select, join::JoinType},
+    catalog::{Catalog, Field, Schema},
+    convert::{IntoOperator, IntoScalar},
+    operator::{Aggregate, Get, Join, Limit, Project, Select, join::JoinType},
+    scalar::{BinaryOp, BinaryOpKind, Function},
     table_ref::TableRef,
     test_utils::test_ctx_with_tables,
 };
 use arrow::datatypes::IntervalMonthDayNano;
+use std::sync::Arc;
+
+fn nullable_test_ctx() -> IRContext {
+    let catalog = crate::magic::MemoryCatalog::new("optd", "public");
+    catalog
+        .create_table(
+            TableRef::bare("t"),
+            Arc::new(Schema::new(vec![
+                Field::new("nullable", DataType::Int32, true),
+                Field::new("not_null", DataType::Int32, false),
+            ])),
+            None,
+        )
+        .unwrap();
+    IRContext::with_memory_catalog(catalog)
+}
 
 // Input plan tree:
 // LogicalSelect [c3 = 20 AND true]
@@ -289,6 +307,149 @@ fn pushes_inner_join_condition_conjuncts_to_inputs() {
     assert!(join.join_cond().used_columns().contains(&t2_c0));
     assert!(!join.join_cond().used_columns().contains(&t1_c1));
     assert!(!join.join_cond().used_columns().contains(&t2_c1));
+}
+
+#[test]
+fn null_rejected_select_converts_left_outer_join_to_inner_join() {
+    let ctx = test_ctx_with_tables(&[("t1", 2), ("t2", 2)]).unwrap();
+    let left = ctx.logical_get(TableRef::bare("t1"), None).unwrap().build();
+    let right = ctx.logical_get(TableRef::bare("t2"), None).unwrap().build();
+    let t2_c0 = ctx.col(Some(&TableRef::bare("t2")), "c0").unwrap();
+
+    let plan = left
+        .with_ctx(&ctx)
+        .logical_join(right, boolean(true), JoinType::LeftOuter)
+        .select(column_ref(t2_c0).eq(int32(10)))
+        .build();
+
+    let simplified = SimplificationPass::new().apply(plan, &ctx).unwrap();
+    let join = simplified.try_borrow::<Join>().unwrap();
+    assert_eq!(join.join_type(), &JoinType::Inner);
+}
+
+#[test]
+fn removes_non_null_self_equality_from_select_predicate() {
+    let ctx = test_ctx_with_tables(&[("t1", 2)]).unwrap();
+    let input = ctx.logical_get(TableRef::bare("t1"), None).unwrap().build();
+    let t1_c0 = ctx.col(Some(&TableRef::bare("t1")), "c0").unwrap();
+    let t1_c1 = ctx.col(Some(&TableRef::bare("t1")), "c1").unwrap();
+
+    let plan = input
+        .with_ctx(&ctx)
+        .select(
+            column_ref(t1_c0)
+                .eq(column_ref(t1_c0))
+                .and(column_ref(t1_c1).gt(int32(5))),
+        )
+        .build();
+
+    let simplified = SimplificationPass::new().apply(plan, &ctx).unwrap();
+    let select = simplified.try_borrow::<Select>().unwrap();
+    assert!(!select.predicate().used_columns().contains(&t1_c0));
+    assert!(select.predicate().used_columns().contains(&t1_c1));
+}
+
+#[test]
+fn keeps_nullable_self_equality_in_select_predicate() {
+    let ctx = nullable_test_ctx();
+    let input = ctx.logical_get(TableRef::bare("t"), None).unwrap().build();
+    let nullable = ctx.col(Some(&TableRef::bare("t")), "nullable").unwrap();
+    let not_null = ctx.col(Some(&TableRef::bare("t")), "not_null").unwrap();
+
+    let plan = input
+        .with_ctx(&ctx)
+        .select(
+            column_ref(nullable)
+                .eq(column_ref(nullable))
+                .and(column_ref(not_null).gt(int32(5))),
+        )
+        .build();
+
+    let simplified = SimplificationPass::new().apply(plan, &ctx).unwrap();
+    let select = simplified.try_borrow::<Select>().unwrap();
+    assert!(select.predicate().used_columns().contains(&nullable));
+    assert!(select.predicate().used_columns().contains(&not_null));
+}
+
+#[test]
+fn removes_redundant_decorrelation_domain_join_after_null_rejection() {
+    let ctx = test_ctx_with_tables(&[("t1", 2), ("t2", 2)]).unwrap();
+    let left = ctx.logical_get(TableRef::bare("t1"), None).unwrap().build();
+    let right = ctx.logical_get(TableRef::bare("t2"), None).unwrap().build();
+    let t1_c0 = ctx.col(Some(&TableRef::bare("t1")), "c0").unwrap();
+    let t1_c1 = ctx.col(Some(&TableRef::bare("t1")), "c1").unwrap();
+    let t2_c0 = ctx.col(Some(&TableRef::bare("t2")), "c0").unwrap();
+    let t2_c1 = ctx.col(Some(&TableRef::bare("t2")), "c1").unwrap();
+
+    let domain = left
+        .clone()
+        .with_ctx(&ctx)
+        .logical_aggregate([], [column_ref(t1_c0)])
+        .unwrap()
+        .build();
+    let domain_key = Column(*domain.borrow::<Aggregate>().key_table_index(), 0);
+
+    let aggregate_expr =
+        Function::new_aggregate("sum", Arc::from([column_ref(t2_c1)]), DataType::Int32)
+            .into_scalar();
+    let value = right
+        .with_ctx(&ctx)
+        .logical_aggregate([aggregate_expr], [column_ref(t2_c0)])
+        .unwrap()
+        .build();
+    let value_agg = value.borrow::<Aggregate>();
+    let value_key = Column(*value_agg.key_table_index(), 0);
+    let value_sum = Column(*value_agg.aggregate_table_index(), 0);
+    drop(value_agg);
+
+    let domain_join_cond =
+        column_ref(domain_key).binary_op(column_ref(value_key), BinaryOpKind::IsNotDistinctFrom);
+    let domain_join = domain
+        .with_ctx(&ctx)
+        .logical_join(value, domain_join_cond, JoinType::LeftOuter)
+        .build();
+
+    let project = ctx
+        .project(domain_join, [column_ref(value_sum), column_ref(domain_key)])
+        .unwrap()
+        .build();
+    let project_table_index = *project.borrow::<Project>().table_index();
+    let project_sum = Column(project_table_index, 0);
+    let project_key = Column(project_table_index, 1);
+
+    let parent_cond = column_ref(t1_c0)
+        .binary_op(column_ref(project_key), BinaryOpKind::IsNotDistinctFrom)
+        .and(column_ref(t1_c1).lt(column_ref(project_sum)));
+    let plan = left
+        .with_ctx(&ctx)
+        .logical_join(project, parent_cond, JoinType::Inner)
+        .build();
+
+    let simplified = SimplificationPass::new().apply(plan, &ctx).unwrap();
+    let join = simplified.try_borrow::<Join>().unwrap();
+    let project = join.inner().try_borrow::<Project>().unwrap();
+
+    assert!(project.input().try_borrow::<Aggregate>().is_ok());
+    assert!(
+        split_conjuncts(join.join_cond().clone())
+            .into_iter()
+            .any(|conjunct| matches!(
+                conjunct
+                    .try_borrow::<BinaryOp>()
+                    .map(|binary| *binary.op_kind()),
+                Ok(BinaryOpKind::Eq)
+            ))
+    );
+    assert!(!contains_left_outer_join(&simplified));
+}
+
+fn contains_left_outer_join(op: &Arc<crate::ir::Operator>) -> bool {
+    if let Ok(join) = op.try_borrow::<Join>()
+        && join.join_type() == &JoinType::LeftOuter
+    {
+        return true;
+    }
+    op.input_operators().iter().any(contains_left_outer_join)
 }
 
 #[test]

--- a/tests/sqlplannertest/tests/tpch/q15.planner.sql
+++ b/tests/sqlplannertest/tests/tpch/q15.planner.sql
@@ -35,6 +35,6 @@ ORDER BY
 
 /*
 Error
-Error during planning: Aggregate requires at least one grouping or aggregate expression. Aggregate without grouping expressions nor aggregate expressions is logically equivalent to, but less efficient than, VALUES producing single row. Please use VALUES instead.
+Schema error: No field named revenue0.total_revenue. Valid fields are "__#22".l_suppkey, "__#22"."sum(lineitem.l_extendedprice * Int64(1) - lineitem.l_discount)".
 */
 

--- a/tests/sqlplannertest/tests/tpch/q17.planner.sql
+++ b/tests/sqlplannertest/tests/tpch/q17.planner.sql
@@ -233,7 +233,7 @@ Project
     └── Join
         ├── .join_type: Inner
         ├── .implementation: None
-        ├── .join_cond: ("part.p_partkey"(#2.0) IS NOT DISTINCT FROM "__#14.p_partkey"(#14.1)) AND (CAST ("lineitem.l_quantity"(#1.4) AS Decimal128(30, 15)) < "__#14.expr0"(#14.0))
+        ├── .join_cond: ("part.p_partkey"(#2.0) = "__#14.p_partkey"(#14.1)) AND (CAST ("lineitem.l_quantity"(#1.4) AS Decimal128(30, 15)) < "__#14.expr0"(#14.0))
         ├── (.output_columns):
         │   ┌── "__#14.expr0"(#14.0)
         │   ├── "__#14.p_partkey"(#14.1)
@@ -274,58 +274,23 @@ Project
         │           └── (.cardinality): 0.00
         └── Project
             ├── .table_index: 14
-            ├── .projections: [ CAST (0.2::float64 * CAST ("__#13.avg"(#13.0) AS Float64) AS Decimal128(30, 15)), "__#10.p_partkey"(#10.0) ]
+            ├── .projections: [ CAST (0.2::float64 * CAST ("__#13.avg"(#13.0) AS Float64) AS Decimal128(30, 15)), "__#12.l_partkey"(#12.0) ]
             ├── (.output_columns): [ "__#14.expr0"(#14.0), "__#14.p_partkey"(#14.1) ]
             ├── (.cardinality): 0.00
-            └── Join
-                ├── .join_type: LeftOuter
+            └── Aggregate
+                ├── .key_table_index: 12
+                ├── .aggregate_table_index: 13
                 ├── .implementation: None
-                ├── .join_cond: "__#10.p_partkey"(#10.0) IS NOT DISTINCT FROM "__#12.l_partkey"(#12.0)
-                ├── (.output_columns): [ "__#10.p_partkey"(#10.0), "__#12.l_partkey"(#12.0), "__#13.avg"(#13.0) ]
+                ├── .exprs: avg("lineitem.l_quantity"(#3.4))
+                ├── .keys: "lineitem.l_partkey"(#3.1)
+                ├── (.output_columns): [ "__#12.l_partkey"(#12.0), "__#13.avg"(#13.0) ]
                 ├── (.cardinality): 0.00
-                ├── Aggregate
-                │   ├── .key_table_index: 10
-                │   ├── .aggregate_table_index: 11
-                │   ├── .implementation: None
-                │   ├── .exprs: []
-                │   ├── .keys: "part.p_partkey"(#2.0)
-                │   ├── (.output_columns): "__#10.p_partkey"(#10.0)
-                │   ├── (.cardinality): 0.00
-                │   └── Join
-                │       ├── .join_type: Inner
-                │       ├── .implementation: None
-                │       ├── .join_cond: "part.p_partkey"(#2.0) = "lineitem.l_partkey"(#1.1)
-                │       ├── (.output_columns): [ "lineitem.l_partkey"(#1.1), "part.p_brand"(#2.3), "part.p_container"(#2.6), "part.p_partkey"(#2.0) ]
-                │       ├── (.cardinality): 0.00
-                │       ├── Get { .data_source_id: 8, .table_index: 1, .implementation: None, (.output_columns): "lineitem.l_partkey"(#1.1), (.cardinality): 0.00 }
-                │       └── Select
-                │           ├── .predicate: ("part.p_brand"(#2.3) = 'Brand#13'::utf8_view) AND ("part.p_container"(#2.6) = 'JUMBO PKG'::utf8_view)
-                │           ├── (.output_columns): [ "part.p_brand"(#2.3), "part.p_container"(#2.6), "part.p_partkey"(#2.0) ]
-                │           ├── (.cardinality): 0.00
-                │           └── Get
-                │               ├── .data_source_id: 3
-                │               ├── .table_index: 2
-                │               ├── .implementation: None
-                │               ├── (.output_columns): [ "part.p_brand"(#2.3), "part.p_container"(#2.6), "part.p_partkey"(#2.0) ]
-                │               └── (.cardinality): 0.00
-                └── Aggregate
-                    ├── .key_table_index: 12
-                    ├── .aggregate_table_index: 13
+                └── Get
+                    ├── .data_source_id: 8
+                    ├── .table_index: 3
                     ├── .implementation: None
-                    ├── .exprs: avg("lineitem.l_quantity"(#3.4))
-                    ├── .keys: "lineitem.l_partkey"(#3.1)
-                    ├── (.output_columns): [ "__#12.l_partkey"(#12.0), "__#13.avg"(#13.0) ]
-                    ├── (.cardinality): 0.00
-                    └── Select
-                        ├── .predicate: "lineitem.l_partkey"(#3.1) = "lineitem.l_partkey"(#3.1)
-                        ├── (.output_columns): [ "lineitem.l_partkey"(#3.1), "lineitem.l_quantity"(#3.4) ]
-                        ├── (.cardinality): 0.00
-                        └── Get
-                            ├── .data_source_id: 8
-                            ├── .table_index: 3
-                            ├── .implementation: None
-                            ├── (.output_columns): [ "lineitem.l_partkey"(#3.1), "lineitem.l_quantity"(#3.4) ]
-                            └── (.cardinality): 0.00
+                    ├── (.output_columns): [ "lineitem.l_partkey"(#3.1), "lineitem.l_quantity"(#3.4) ]
+                    └── (.cardinality): 0.00
 
 NULL
 */

--- a/tests/sqlplannertest/tests/tpch/q2.planner.sql
+++ b/tests/sqlplannertest/tests/tpch/q2.planner.sql
@@ -371,7 +371,7 @@ Limit
         └── Join
             ├── .join_type: Inner
             ├── .implementation: None
-            ├── .join_cond: ("part.p_partkey"(#1.0) IS NOT DISTINCT FROM "__#18.p_partkey"(#18.1)) AND ("partsupp.ps_supplycost"(#3.3) = "__#18.min"(#18.0))
+            ├── .join_cond: ("part.p_partkey"(#1.0) = "__#18.p_partkey"(#18.1)) AND ("partsupp.ps_supplycost"(#3.3) = "__#18.min"(#18.0))
             ├── (.output_columns):
             │   ┌── "__#18.min"(#18.0)
             │   ├── "__#18.p_partkey"(#18.1)
@@ -527,195 +527,83 @@ Limit
             │           └── (.cardinality): 0.00
             └── Project
                 ├── .table_index: 18
-                ├── .projections: [ "__#17.min"(#17.0), "__#14.p_partkey"(#14.0) ]
+                ├── .projections: [ "__#17.min"(#17.0), "__#16.ps_partkey"(#16.0) ]
                 ├── (.output_columns): [ "__#18.min"(#18.0), "__#18.p_partkey"(#18.1) ]
                 ├── (.cardinality): 0.00
-                └── Join
-                    ├── .join_type: LeftOuter
+                └── Aggregate
+                    ├── .key_table_index: 16
+                    ├── .aggregate_table_index: 17
                     ├── .implementation: None
-                    ├── .join_cond: "__#14.p_partkey"(#14.0) IS NOT DISTINCT FROM "__#16.ps_partkey"(#16.0)
-                    ├── (.output_columns): [ "__#14.p_partkey"(#14.0), "__#16.ps_partkey"(#16.0), "__#17.min"(#17.0) ]
+                    ├── .exprs: min("partsupp.ps_supplycost"(#6.3))
+                    ├── .keys: "partsupp.ps_partkey"(#6.0)
+                    ├── (.output_columns): [ "__#16.ps_partkey"(#16.0), "__#17.min"(#17.0) ]
                     ├── (.cardinality): 0.00
-                    ├── Aggregate
-                    │   ├── .key_table_index: 14
-                    │   ├── .aggregate_table_index: 15
-                    │   ├── .implementation: None
-                    │   ├── .exprs: []
-                    │   ├── .keys: "part.p_partkey"(#1.0)
-                    │   ├── (.output_columns): "__#14.p_partkey"(#14.0)
-                    │   ├── (.cardinality): 0.00
-                    │   └── Join
-                    │       ├── .join_type: Inner
-                    │       ├── .implementation: None
-                    │       ├── .join_cond: "nation.n_regionkey"(#4.2) = "region.r_regionkey"(#5.0)
-                    │       ├── (.output_columns):
-                    │       │   ┌── "nation.n_nationkey"(#4.0)
-                    │       │   ├── "nation.n_regionkey"(#4.2)
-                    │       │   ├── "part.p_partkey"(#1.0)
-                    │       │   ├── "part.p_size"(#1.5)
-                    │       │   ├── "part.p_type"(#1.4)
-                    │       │   ├── "partsupp.ps_partkey"(#3.0)
-                    │       │   ├── "partsupp.ps_suppkey"(#3.1)
-                    │       │   ├── "region.r_name"(#5.1)
-                    │       │   ├── "region.r_regionkey"(#5.0)
-                    │       │   ├── "supplier.s_nationkey"(#2.3)
-                    │       │   └── "supplier.s_suppkey"(#2.0)
-                    │       ├── (.cardinality): 0.00
-                    │       ├── Join
-                    │       │   ├── .join_type: Inner
-                    │       │   ├── .implementation: None
-                    │       │   ├── .join_cond: "supplier.s_nationkey"(#2.3) = "nation.n_nationkey"(#4.0)
-                    │       │   ├── (.output_columns):
-                    │       │   │   ┌── "nation.n_nationkey"(#4.0)
-                    │       │   │   ├── "nation.n_regionkey"(#4.2)
-                    │       │   │   ├── "part.p_partkey"(#1.0)
-                    │       │   │   ├── "part.p_size"(#1.5)
-                    │       │   │   ├── "part.p_type"(#1.4)
-                    │       │   │   ├── "partsupp.ps_partkey"(#3.0)
-                    │       │   │   ├── "partsupp.ps_suppkey"(#3.1)
-                    │       │   │   ├── "supplier.s_nationkey"(#2.3)
-                    │       │   │   └── "supplier.s_suppkey"(#2.0)
-                    │       │   ├── (.cardinality): 0.00
-                    │       │   ├── Join
-                    │       │   │   ├── .join_type: Inner
-                    │       │   │   ├── .implementation: None
-                    │       │   │   ├── .join_cond: ("part.p_partkey"(#1.0) = "partsupp.ps_partkey"(#3.0)) AND ("supplier.s_suppkey"(#2.0) = "partsupp.ps_suppkey"(#3.1))
-                    │       │   │   ├── (.output_columns):
-                    │       │   │   │   ┌── "part.p_partkey"(#1.0)
-                    │       │   │   │   ├── "part.p_size"(#1.5)
-                    │       │   │   │   ├── "part.p_type"(#1.4)
-                    │       │   │   │   ├── "partsupp.ps_partkey"(#3.0)
-                    │       │   │   │   ├── "partsupp.ps_suppkey"(#3.1)
-                    │       │   │   │   ├── "supplier.s_nationkey"(#2.3)
-                    │       │   │   │   └── "supplier.s_suppkey"(#2.0)
-                    │       │   │   ├── (.cardinality): 0.00
-                    │       │   │   ├── Join
-                    │       │   │   │   ├── .join_type: Inner
-                    │       │   │   │   ├── .implementation: None
-                    │       │   │   │   ├── .join_cond: true::boolean
-                    │       │   │   │   ├── (.output_columns):
-                    │       │   │   │   │   ┌── "part.p_partkey"(#1.0)
-                    │       │   │   │   │   ├── "part.p_size"(#1.5)
-                    │       │   │   │   │   ├── "part.p_type"(#1.4)
-                    │       │   │   │   │   ├── "supplier.s_nationkey"(#2.3)
-                    │       │   │   │   │   └── "supplier.s_suppkey"(#2.0)
-                    │       │   │   │   ├── (.cardinality): 0.00
-                    │       │   │   │   ├── Select
-                    │       │   │   │   │   ├── .predicate: ("part.p_size"(#1.5) = 4::integer) AND ("part.p_type"(#1.4) LIKE '%TIN'::utf8_view)
-                    │       │   │   │   │   ├── (.output_columns): [ "part.p_partkey"(#1.0), "part.p_size"(#1.5), "part.p_type"(#1.4) ]
-                    │       │   │   │   │   ├── (.cardinality): 0.00
-                    │       │   │   │   │   └── Get
-                    │       │   │   │   │       ├── .data_source_id: 3
-                    │       │   │   │   │       ├── .table_index: 1
-                    │       │   │   │   │       ├── .implementation: None
-                    │       │   │   │   │       ├── (.output_columns): [ "part.p_partkey"(#1.0), "part.p_size"(#1.5), "part.p_type"(#1.4) ]
-                    │       │   │   │   │       └── (.cardinality): 0.00
-                    │       │   │   │   └── Get
-                    │       │   │   │       ├── .data_source_id: 4
-                    │       │   │   │       ├── .table_index: 2
-                    │       │   │   │       ├── .implementation: None
-                    │       │   │   │       ├── (.output_columns): [ "supplier.s_nationkey"(#2.3), "supplier.s_suppkey"(#2.0) ]
-                    │       │   │   │       └── (.cardinality): 0.00
-                    │       │   │   └── Get
-                    │       │   │       ├── .data_source_id: 5
-                    │       │   │       ├── .table_index: 3
-                    │       │   │       ├── .implementation: None
-                    │       │   │       ├── (.output_columns): [ "partsupp.ps_partkey"(#3.0), "partsupp.ps_suppkey"(#3.1) ]
-                    │       │   │       └── (.cardinality): 0.00
-                    │       │   └── Get
-                    │       │       ├── .data_source_id: 1
-                    │       │       ├── .table_index: 4
-                    │       │       ├── .implementation: None
-                    │       │       ├── (.output_columns): [ "nation.n_nationkey"(#4.0), "nation.n_regionkey"(#4.2) ]
-                    │       │       └── (.cardinality): 0.00
-                    │       └── Select
-                    │           ├── .predicate: "region.r_name"(#5.1) = 'AFRICA'::utf8_view
-                    │           ├── (.output_columns): [ "region.r_name"(#5.1), "region.r_regionkey"(#5.0) ]
-                    │           ├── (.cardinality): 0.00
-                    │           └── Get
-                    │               ├── .data_source_id: 2
-                    │               ├── .table_index: 5
-                    │               ├── .implementation: None
-                    │               ├── (.output_columns): [ "region.r_name"(#5.1), "region.r_regionkey"(#5.0) ]
-                    │               └── (.cardinality): 0.00
-                    └── Aggregate
-                        ├── .key_table_index: 16
-                        ├── .aggregate_table_index: 17
+                    └── Join
+                        ├── .join_type: Inner
                         ├── .implementation: None
-                        ├── .exprs: min("partsupp.ps_supplycost"(#6.3))
-                        ├── .keys: "partsupp.ps_partkey"(#6.0)
-                        ├── (.output_columns): [ "__#16.ps_partkey"(#16.0), "__#17.min"(#17.0) ]
+                        ├── .join_cond: "nation.n_regionkey"(#8.2) = "region.r_regionkey"(#9.0)
+                        ├── (.output_columns):
+                        │   ┌── "nation.n_nationkey"(#8.0)
+                        │   ├── "nation.n_regionkey"(#8.2)
+                        │   ├── "partsupp.ps_partkey"(#6.0)
+                        │   ├── "partsupp.ps_suppkey"(#6.1)
+                        │   ├── "partsupp.ps_supplycost"(#6.3)
+                        │   ├── "region.r_name"(#9.1)
+                        │   ├── "region.r_regionkey"(#9.0)
+                        │   ├── "supplier.s_nationkey"(#7.3)
+                        │   └── "supplier.s_suppkey"(#7.0)
                         ├── (.cardinality): 0.00
-                        └── Join
-                            ├── .join_type: Inner
-                            ├── .implementation: None
-                            ├── .join_cond: "nation.n_regionkey"(#8.2) = "region.r_regionkey"(#9.0)
-                            ├── (.output_columns):
-                            │   ┌── "nation.n_nationkey"(#8.0)
-                            │   ├── "nation.n_regionkey"(#8.2)
-                            │   ├── "partsupp.ps_partkey"(#6.0)
-                            │   ├── "partsupp.ps_suppkey"(#6.1)
-                            │   ├── "partsupp.ps_supplycost"(#6.3)
-                            │   ├── "region.r_name"(#9.1)
-                            │   ├── "region.r_regionkey"(#9.0)
-                            │   ├── "supplier.s_nationkey"(#7.3)
-                            │   └── "supplier.s_suppkey"(#7.0)
+                        ├── Join
+                        │   ├── .join_type: Inner
+                        │   ├── .implementation: None
+                        │   ├── .join_cond: "supplier.s_nationkey"(#7.3) = "nation.n_nationkey"(#8.0)
+                        │   ├── (.output_columns):
+                        │   │   ┌── "nation.n_nationkey"(#8.0)
+                        │   │   ├── "nation.n_regionkey"(#8.2)
+                        │   │   ├── "partsupp.ps_partkey"(#6.0)
+                        │   │   ├── "partsupp.ps_suppkey"(#6.1)
+                        │   │   ├── "partsupp.ps_supplycost"(#6.3)
+                        │   │   ├── "supplier.s_nationkey"(#7.3)
+                        │   │   └── "supplier.s_suppkey"(#7.0)
+                        │   ├── (.cardinality): 0.00
+                        │   ├── Join
+                        │   │   ├── .join_type: Inner
+                        │   │   ├── .implementation: None
+                        │   │   ├── .join_cond: "supplier.s_suppkey"(#7.0) = "partsupp.ps_suppkey"(#6.1)
+                        │   │   ├── (.output_columns):
+                        │   │   │   ┌── "partsupp.ps_partkey"(#6.0)
+                        │   │   │   ├── "partsupp.ps_suppkey"(#6.1)
+                        │   │   │   ├── "partsupp.ps_supplycost"(#6.3)
+                        │   │   │   ├── "supplier.s_nationkey"(#7.3)
+                        │   │   │   └── "supplier.s_suppkey"(#7.0)
+                        │   │   ├── (.cardinality): 0.00
+                        │   │   ├── Get
+                        │   │   │   ├── .data_source_id: 5
+                        │   │   │   ├── .table_index: 6
+                        │   │   │   ├── .implementation: None
+                        │   │   │   ├── (.output_columns): [ "partsupp.ps_partkey"(#6.0), "partsupp.ps_suppkey"(#6.1), "partsupp.ps_supplycost"(#6.3) ]
+                        │   │   │   └── (.cardinality): 0.00
+                        │   │   └── Get
+                        │   │       ├── .data_source_id: 4
+                        │   │       ├── .table_index: 7
+                        │   │       ├── .implementation: None
+                        │   │       ├── (.output_columns): [ "supplier.s_nationkey"(#7.3), "supplier.s_suppkey"(#7.0) ]
+                        │   │       └── (.cardinality): 0.00
+                        │   └── Get
+                        │       ├── .data_source_id: 1
+                        │       ├── .table_index: 8
+                        │       ├── .implementation: None
+                        │       ├── (.output_columns): [ "nation.n_nationkey"(#8.0), "nation.n_regionkey"(#8.2) ]
+                        │       └── (.cardinality): 0.00
+                        └── Select
+                            ├── .predicate: "region.r_name"(#9.1) = 'AFRICA'::utf8_view
+                            ├── (.output_columns): [ "region.r_name"(#9.1), "region.r_regionkey"(#9.0) ]
                             ├── (.cardinality): 0.00
-                            ├── Join
-                            │   ├── .join_type: Inner
-                            │   ├── .implementation: None
-                            │   ├── .join_cond: "supplier.s_nationkey"(#7.3) = "nation.n_nationkey"(#8.0)
-                            │   ├── (.output_columns):
-                            │   │   ┌── "nation.n_nationkey"(#8.0)
-                            │   │   ├── "nation.n_regionkey"(#8.2)
-                            │   │   ├── "partsupp.ps_partkey"(#6.0)
-                            │   │   ├── "partsupp.ps_suppkey"(#6.1)
-                            │   │   ├── "partsupp.ps_supplycost"(#6.3)
-                            │   │   ├── "supplier.s_nationkey"(#7.3)
-                            │   │   └── "supplier.s_suppkey"(#7.0)
-                            │   ├── (.cardinality): 0.00
-                            │   ├── Join
-                            │   │   ├── .join_type: Inner
-                            │   │   ├── .implementation: None
-                            │   │   ├── .join_cond: "supplier.s_suppkey"(#7.0) = "partsupp.ps_suppkey"(#6.1)
-                            │   │   ├── (.output_columns):
-                            │   │   │   ┌── "partsupp.ps_partkey"(#6.0)
-                            │   │   │   ├── "partsupp.ps_suppkey"(#6.1)
-                            │   │   │   ├── "partsupp.ps_supplycost"(#6.3)
-                            │   │   │   ├── "supplier.s_nationkey"(#7.3)
-                            │   │   │   └── "supplier.s_suppkey"(#7.0)
-                            │   │   ├── (.cardinality): 0.00
-                            │   │   ├── Select
-                            │   │   │   ├── .predicate: "partsupp.ps_partkey"(#6.0) = "partsupp.ps_partkey"(#6.0)
-                            │   │   │   ├── (.output_columns): [ "partsupp.ps_partkey"(#6.0), "partsupp.ps_suppkey"(#6.1), "partsupp.ps_supplycost"(#6.3) ]
-                            │   │   │   ├── (.cardinality): 0.00
-                            │   │   │   └── Get
-                            │   │   │       ├── .data_source_id: 5
-                            │   │   │       ├── .table_index: 6
-                            │   │   │       ├── .implementation: None
-                            │   │   │       ├── (.output_columns): [ "partsupp.ps_partkey"(#6.0), "partsupp.ps_suppkey"(#6.1), "partsupp.ps_supplycost"(#6.3) ]
-                            │   │   │       └── (.cardinality): 0.00
-                            │   │   └── Get
-                            │   │       ├── .data_source_id: 4
-                            │   │       ├── .table_index: 7
-                            │   │       ├── .implementation: None
-                            │   │       ├── (.output_columns): [ "supplier.s_nationkey"(#7.3), "supplier.s_suppkey"(#7.0) ]
-                            │   │       └── (.cardinality): 0.00
-                            │   └── Get
-                            │       ├── .data_source_id: 1
-                            │       ├── .table_index: 8
-                            │       ├── .implementation: None
-                            │       ├── (.output_columns): [ "nation.n_nationkey"(#8.0), "nation.n_regionkey"(#8.2) ]
-                            │       └── (.cardinality): 0.00
-                            └── Select
-                                ├── .predicate: "region.r_name"(#9.1) = 'AFRICA'::utf8_view
+                            └── Get
+                                ├── .data_source_id: 2
+                                ├── .table_index: 9
+                                ├── .implementation: None
                                 ├── (.output_columns): [ "region.r_name"(#9.1), "region.r_regionkey"(#9.0) ]
-                                ├── (.cardinality): 0.00
-                                └── Get
-                                    ├── .data_source_id: 2
-                                    ├── .table_index: 9
-                                    ├── .implementation: None
-                                    ├── (.output_columns): [ "region.r_name"(#9.1), "region.r_regionkey"(#9.0) ]
-                                    └── (.cardinality): 0.00
+                                └── (.cardinality): 0.00
 */
 

--- a/tests/sqlplannertest/tests/tpch/q20.planner.sql
+++ b/tests/sqlplannertest/tests/tpch/q20.planner.sql
@@ -129,57 +129,53 @@ EnforcerSort { tuple_ordering: [(#11.0, Asc)], (.output_columns): [ "__#11.s_add
         │   ├── .join_cond: "supplier.s_nationkey"(#1.3) = "nation.n_nationkey"(#2.0)
         │   ├── (.output_columns): [ "nation.n_name"(#2.1), "nation.n_nationkey"(#2.0), "supplier.s_address"(#1.2), "supplier.s_name"(#1.1), "supplier.s_nationkey"(#1.3), "supplier.s_suppkey"(#1.0) ]
         │   ├── (.cardinality): 0.00
-        │   ├── Get { .data_source_id: 4, .table_index: 1, .implementation: None, (.output_columns): [ "supplier.s_address"(#1.2), "supplier.s_name"(#1.1), "supplier.s_nationkey"(#1.3), "supplier.s_suppkey"(#1.0) ], (.cardinality): 0.00 }
+        │   ├── Get
+        │   │   ├── .data_source_id: 4
+        │   │   ├── .table_index: 1
+        │   │   ├── .implementation: None
+        │   │   ├── (.output_columns): [ "supplier.s_address"(#1.2), "supplier.s_name"(#1.1), "supplier.s_nationkey"(#1.3), "supplier.s_suppkey"(#1.0) ]
+        │   │   └── (.cardinality): 0.00
         │   └── Select { .predicate: "nation.n_name"(#2.1) = 'IRAQ'::utf8_view, (.output_columns): [ "nation.n_name"(#2.1), "nation.n_nationkey"(#2.0) ], (.cardinality): 0.00 }
         │       └── Get { .data_source_id: 1, .table_index: 2, .implementation: None, (.output_columns): [ "nation.n_name"(#2.1), "nation.n_nationkey"(#2.0) ], (.cardinality): 0.00 }
         └── Project { .table_index: 19, .projections: "partsupp.ps_suppkey"(#3.1), (.output_columns): "__#19.ps_suppkey"(#19.0), (.cardinality): 0.00 }
             └── Join
                 ├── .join_type: Inner
                 ├── .implementation: None
-                ├── .join_cond: ("partsupp.ps_partkey"(#3.0) IS NOT DISTINCT FROM "__#18.ps_partkey"(#18.1)) AND ("partsupp.ps_suppkey"(#3.1) IS NOT DISTINCT FROM "__#18.ps_suppkey"(#18.2)) AND (CAST ("partsupp.ps_availqty"(#3.2) AS Float64) > "__#18.expr0"(#18.0))
+                ├── .join_cond: ("partsupp.ps_partkey"(#3.0) = "__#18.ps_partkey"(#18.1)) AND ("partsupp.ps_suppkey"(#3.1) = "__#18.ps_suppkey"(#18.2)) AND (CAST ("partsupp.ps_availqty"(#3.2) AS Float64) > "__#18.expr0"(#18.0))
                 ├── (.output_columns): [ "__#18.expr0"(#18.0), "__#18.ps_partkey"(#18.1), "__#18.ps_suppkey"(#18.2), "partsupp.ps_availqty"(#3.2), "partsupp.ps_partkey"(#3.0), "partsupp.ps_suppkey"(#3.1) ]
                 ├── (.cardinality): 0.00
-                ├── Join { .join_type: LeftSemi, .implementation: None, .join_cond: "partsupp.ps_partkey"(#3.0) = "__#5.p_partkey"(#5.0), (.output_columns): [ "partsupp.ps_availqty"(#3.2), "partsupp.ps_partkey"(#3.0), "partsupp.ps_suppkey"(#3.1) ], (.cardinality): 0.00 }
+                ├── Join
+                │   ├── .join_type: LeftSemi
+                │   ├── .implementation: None
+                │   ├── .join_cond: "partsupp.ps_partkey"(#3.0) = "__#5.p_partkey"(#5.0)
+                │   ├── (.output_columns): [ "partsupp.ps_availqty"(#3.2), "partsupp.ps_partkey"(#3.0), "partsupp.ps_suppkey"(#3.1) ]
+                │   ├── (.cardinality): 0.00
                 │   ├── Get { .data_source_id: 5, .table_index: 3, .implementation: None, (.output_columns): [ "partsupp.ps_availqty"(#3.2), "partsupp.ps_partkey"(#3.0), "partsupp.ps_suppkey"(#3.1) ], (.cardinality): 0.00 }
                 │   └── Project { .table_index: 5, .projections: "part.p_partkey"(#4.0), (.output_columns): "__#5.p_partkey"(#5.0), (.cardinality): 0.00 }
                 │       └── Select { .predicate: "part.p_name"(#4.1) LIKE 'indian%'::utf8_view, (.output_columns): [ "part.p_name"(#4.1), "part.p_partkey"(#4.0) ], (.cardinality): 0.00 }
                 │           └── Get { .data_source_id: 3, .table_index: 4, .implementation: None, (.output_columns): [ "part.p_name"(#4.1), "part.p_partkey"(#4.0) ], (.cardinality): 0.00 }
                 └── Project
                     ├── .table_index: 18
-                    ├── .projections: [ 0.5::float64 * CAST ("__#17.sum"(#17.0) AS Float64), "__#14.ps_partkey"(#14.0), "__#14.ps_suppkey"(#14.1) ]
+                    ├── .projections: [ 0.5::float64 * CAST ("__#17.sum"(#17.0) AS Float64), "__#16.l_partkey"(#16.0), "__#16.l_suppkey"(#16.1) ]
                     ├── (.output_columns): [ "__#18.expr0"(#18.0), "__#18.ps_partkey"(#18.1), "__#18.ps_suppkey"(#18.2) ]
                     ├── (.cardinality): 0.00
-                    └── Join
-                        ├── .join_type: LeftOuter
+                    └── Aggregate
+                        ├── .key_table_index: 16
+                        ├── .aggregate_table_index: 17
                         ├── .implementation: None
-                        ├── .join_cond: ("__#14.ps_partkey"(#14.0) IS NOT DISTINCT FROM "__#16.l_partkey"(#16.0)) AND ("__#14.ps_suppkey"(#14.1) IS NOT DISTINCT FROM "__#16.l_suppkey"(#16.1))
-                        ├── (.output_columns): [ "__#14.ps_partkey"(#14.0), "__#14.ps_suppkey"(#14.1), "__#16.l_partkey"(#16.0), "__#16.l_suppkey"(#16.1), "__#17.sum"(#17.0) ]
+                        ├── .exprs: sum("lineitem.l_quantity"(#6.4))
+                        ├── .keys: [ "lineitem.l_partkey"(#6.1), "lineitem.l_suppkey"(#6.2) ]
+                        ├── (.output_columns): [ "__#16.l_partkey"(#16.0), "__#16.l_suppkey"(#16.1), "__#17.sum"(#17.0) ]
                         ├── (.cardinality): 0.00
-                        ├── Aggregate
-                        │   ├── .key_table_index: 14
-                        │   ├── .aggregate_table_index: 15
-                        │   ├── .implementation: None
-                        │   ├── .exprs: []
-                        │   ├── .keys: [ "partsupp.ps_partkey"(#3.0), "partsupp.ps_suppkey"(#3.1) ]
-                        │   ├── (.output_columns): [ "__#14.ps_partkey"(#14.0), "__#14.ps_suppkey"(#14.1) ]
-                        │   ├── (.cardinality): 0.00
-                        │   └── Join { .join_type: LeftSemi, .implementation: None, .join_cond: "partsupp.ps_partkey"(#3.0) = "__#5.p_partkey"(#5.0), (.output_columns): [ "partsupp.ps_partkey"(#3.0), "partsupp.ps_suppkey"(#3.1) ], (.cardinality): 0.00 }
-                        │       ├── Get { .data_source_id: 5, .table_index: 3, .implementation: None, (.output_columns): [ "partsupp.ps_partkey"(#3.0), "partsupp.ps_suppkey"(#3.1) ], (.cardinality): 0.00 }
-                        │       └── Project { .table_index: 5, .projections: "part.p_partkey"(#4.0), (.output_columns): "__#5.p_partkey"(#5.0), (.cardinality): 0.00 }
-                        │           └── Select { .predicate: "part.p_name"(#4.1) LIKE 'indian%'::utf8_view, (.output_columns): [ "part.p_name"(#4.1), "part.p_partkey"(#4.0) ], (.cardinality): 0.00 }
-                        │               └── Get { .data_source_id: 3, .table_index: 4, .implementation: None, (.output_columns): [ "part.p_name"(#4.1), "part.p_partkey"(#4.0) ], (.cardinality): 0.00 }
-                        └── Aggregate
-                            ├── .key_table_index: 16
-                            ├── .aggregate_table_index: 17
-                            ├── .implementation: None
-                            ├── .exprs: sum("lineitem.l_quantity"(#6.4))
-                            ├── .keys: [ "lineitem.l_partkey"(#6.1), "lineitem.l_suppkey"(#6.2) ]
-                            ├── (.output_columns): [ "__#16.l_partkey"(#16.0), "__#16.l_suppkey"(#16.1), "__#17.sum"(#17.0) ]
+                        └── Select
+                            ├── .predicate: ("lineitem.l_shipdate"(#6.10) >= 1996-01-01::date32) AND ("lineitem.l_shipdate"(#6.10) < 1997-01-01::date32)
+                            ├── (.output_columns): [ "lineitem.l_partkey"(#6.1), "lineitem.l_quantity"(#6.4), "lineitem.l_shipdate"(#6.10), "lineitem.l_suppkey"(#6.2) ]
                             ├── (.cardinality): 0.00
-                            └── Select
-                                ├── .predicate: ("lineitem.l_partkey"(#6.1) = "lineitem.l_partkey"(#6.1)) AND ("lineitem.l_suppkey"(#6.2) = "lineitem.l_suppkey"(#6.2)) AND ("lineitem.l_shipdate"(#6.10) >= 1996-01-01::date32) AND ("lineitem.l_shipdate"(#6.10) < 1997-01-01::date32)
+                            └── Get
+                                ├── .data_source_id: 8
+                                ├── .table_index: 6
+                                ├── .implementation: None
                                 ├── (.output_columns): [ "lineitem.l_partkey"(#6.1), "lineitem.l_quantity"(#6.4), "lineitem.l_shipdate"(#6.10), "lineitem.l_suppkey"(#6.2) ]
-                                ├── (.cardinality): 0.00
-                                └── Get { .data_source_id: 8, .table_index: 6, .implementation: None, (.output_columns): [ "lineitem.l_partkey"(#6.1), "lineitem.l_quantity"(#6.4), "lineitem.l_shipdate"(#6.10), "lineitem.l_suppkey"(#6.2) ], (.cardinality): 0.00 }
+                                └── (.cardinality): 0.00
 */
 

--- a/tests/sqlplannertest/tests/tpch/q21.planner.sql
+++ b/tests/sqlplannertest/tests/tpch/q21.planner.sql
@@ -42,6 +42,6 @@ limit 100;
 
 /*
 Error
-Schema error: Schema contains duplicate qualified field name "__#20".l_orderkey
+External error: Schema error: Schema contains duplicate fields: __#20.l_orderkey
 */
 

--- a/tests/sqlplannertest/tests/tpch/q22.planner.sql
+++ b/tests/sqlplannertest/tests/tpch/q22.planner.sql
@@ -130,8 +130,10 @@ EnforcerSort { tuple_ordering: [(#12.0, Asc)], (.output_columns): [ "__#12.cntry
                         │   ├── "__#15.o_shippriority"(#15.7)
                         │   └── "__#15.o_totalprice"(#15.3)
                         ├── (.cardinality): 0.00
-                        └── Select
-                            ├── .predicate: "orders.o_custkey"(#6.1) = "orders.o_custkey"(#6.1)
+                        └── Get
+                            ├── .data_source_id: 7
+                            ├── .table_index: 6
+                            ├── .implementation: None
                             ├── (.output_columns):
                             │   ┌── "orders.o_clerk"(#6.6)
                             │   ├── "orders.o_comment"(#6.8)
@@ -142,21 +144,6 @@ EnforcerSort { tuple_ordering: [(#12.0, Asc)], (.output_columns): [ "__#12.cntry
                             │   ├── "orders.o_orderstatus"(#6.2)
                             │   ├── "orders.o_shippriority"(#6.7)
                             │   └── "orders.o_totalprice"(#6.3)
-                            ├── (.cardinality): 0.00
-                            └── Get
-                                ├── .data_source_id: 7
-                                ├── .table_index: 6
-                                ├── .implementation: None
-                                ├── (.output_columns):
-                                │   ┌── "orders.o_clerk"(#6.6)
-                                │   ├── "orders.o_comment"(#6.8)
-                                │   ├── "orders.o_custkey"(#6.1)
-                                │   ├── "orders.o_orderdate"(#6.4)
-                                │   ├── "orders.o_orderkey"(#6.0)
-                                │   ├── "orders.o_orderpriority"(#6.5)
-                                │   ├── "orders.o_orderstatus"(#6.2)
-                                │   ├── "orders.o_shippriority"(#6.7)
-                                │   └── "orders.o_totalprice"(#6.3)
-                                └── (.cardinality): 0.00
+                            └── (.cardinality): 0.00
 */
 

--- a/tests/sqlplannertest/tests/tpch/q4.planner.sql
+++ b/tests/sqlplannertest/tests/tpch/q4.planner.sql
@@ -156,7 +156,10 @@ OrderBy { ordering_exprs: "__#6.o_orderpriority"(#6.0) ASC, (.output_columns): [
                         └── (.cardinality): 0.00
 
 physical_plan after optd-finalized:
-EnforcerSort { tuple_ordering: [(#6.0, Asc)], (.output_columns): [ "__#6.o_orderpriority"(#6.0), "__#6.order_count"(#6.1) ], (.cardinality): 0.00 }
+EnforcerSort
+├── tuple_ordering: [(#6.0, Asc)]
+├── (.output_columns): [ "__#6.o_orderpriority"(#6.0), "__#6.order_count"(#6.1) ]
+├── (.cardinality): 0.00
 └── Project
     ├── .table_index: 6
     ├── .projections: [ "orders.o_orderpriority"(#1.5), "__#5.count(Int64(1))"(#5.0) ]
@@ -224,7 +227,7 @@ EnforcerSort { tuple_ordering: [(#6.0, Asc)], (.output_columns): [ "__#6.o_order
                 │   └── "__#9.l_tax"(#9.7)
                 ├── (.cardinality): 0.00
                 └── Select
-                    ├── .predicate: ("lineitem.l_orderkey"(#2.0) = "lineitem.l_orderkey"(#2.0)) AND ("lineitem.l_commitdate"(#2.11) < "lineitem.l_receiptdate"(#2.12))
+                    ├── .predicate: "lineitem.l_commitdate"(#2.11) < "lineitem.l_receiptdate"(#2.12)
                     ├── (.output_columns):
                     │   ┌── "lineitem.l_comment"(#2.15)
                     │   ├── "lineitem.l_commitdate"(#2.11)


### PR DESCRIPTION
## Problem

Some extraneous domain joins were inserted into TPCH queries due to a missing simplification rule about converting LeftJoins into InnerJoins and propagating that downward.

## Summary of changes

2 new rules are added:
- The first converts left joins into inner joins when there are null rejecting predicates on the right branch
- Given inner joins, unnecessary domain joins under them are removed
